### PR TITLE
SEO: 全ページにtitle・description・openGraph・canonical統一設定 + リファクタリング

### DIFF
--- a/app/_components/MemberCarousel/index.tsx
+++ b/app/_components/MemberCarousel/index.tsx
@@ -4,8 +4,7 @@ import { useRef, useState, useCallback, useEffect } from 'react';
 import Image from 'next/image';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import type { Member } from '@/app/_libs/microcms';
-import { optimizeImageUrl } from '@/app/_libs/microcms';
-import { extractName } from '@/app/_libs/utils';
+import { optimizeImageUrl, extractName } from '@/app/_libs/utils';
 import styles from './index.module.css';
 
 const CARD_SCROLL_UNIT = 280 + 24; // card width + gap

--- a/app/_components/ReportsListItem/index.tsx
+++ b/app/_components/ReportsListItem/index.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
-import { Report, optimizeImageUrl } from '@/app/_libs/microcms';
+import type { Report } from '@/app/_libs/microcms';
+import { optimizeImageUrl } from '@/app/_libs/utils';
 import styles from './index.module.css';
 import PublishedDate from '../Date';
 import Category from '../Category';

--- a/app/_constants/index.ts
+++ b/app/_constants/index.ts
@@ -1,7 +1,11 @@
 // SEO
+// テンプレート・OG siteName・構造化データ・UI用（短縮ブランド名）
 export const SITE_NAME = '放課後こどもラボ PLDL';
+// ホームページ用 <title>（SERP表示幅 ~30全角文字に最適化）
+export const SITE_TITLE = '放課後こどもラボ | 群馬県みどり市のNPO法人PLDL';
+// meta description（英語正式名を含め、英語検索にも対応）
 export const SITE_DESCRIPTION =
-  'NPO法人PLDLが運営する放課後こどもラボ。群馬県みどり市を拠点に、こどもたちのサードプレイスとして創造的な学び（Playful Learning）を提供しています。';
+  'NPO法人PLDL（Playful Learning Design Lab.）が運営する放課後こどもラボ。群馬県みどり市を拠点に、こどもたちのサードプレイスとして創造的な学びを提供しています。';
 export const DEFAULT_OG_IMAGE = '/ogp.webp';
 export const DEFAULT_OG_IMAGE_FALLBACK = '/ogp.jpg';
 

--- a/app/_libs/microcms.ts
+++ b/app/_libs/microcms.ts
@@ -167,14 +167,6 @@ export const getRelatedReports = async (categoryId: string, excludeId: string) =
   return listData?.contents ?? [];
 };
 
-// microCMS 画像URLに最適化パラメータを付与
-export const optimizeImageUrl = (url: string, width: number): string => {
-  const u = new URL(url);
-  u.searchParams.set('w', String(width));
-  u.searchParams.set('fm', 'webp');
-  return u.toString();
-};
-
 // メタ情報を取得
 export const getMeta = async (queries?: MicroCMSQueries) => {
   const data = await client

--- a/app/_libs/utils.ts
+++ b/app/_libs/utils.ts
@@ -13,6 +13,14 @@ export const formatDateDot = (dateStr: string): string => {
   return `${y}.${m}.${day}`;
 };
 
+// microCMS 画像URLに最適化パラメータを付与
+export const optimizeImageUrl = (url: string, width: number): string => {
+  const u = new URL(url);
+  u.searchParams.set('w', String(width));
+  u.searchParams.set('fm', 'webp');
+  return u.toString();
+};
+
 // メンバー名から「役職：名前」形式の名前部分を抽出
 export const extractName = (raw: string): string => {
   const idx = raw.indexOf('：');

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Image from 'next/image';
 import { FileText } from 'lucide-react';
 
-import { getMembersList } from '@/app/_libs/microcms';
+import { getMembersList, type Member } from '@/app/_libs/microcms';
 import Hero from '@/app/_components/Hero';
 import VisionSection from '@/app/_components/VisionSection';
 import MissionSection from '@/app/_components/MissionSection';
@@ -15,6 +15,11 @@ export const metadata: Metadata = {
   title: '私たちについて',
   description:
     'NPO法人PLDLのVision・Mission・メンバー紹介。すべてのこどもたちの個性を活かし、未来をより良くする社会の実現を目指します。',
+  openGraph: {
+    title: '私たちについて',
+    description:
+      'NPO法人PLDLのVision・Mission・メンバー紹介。すべてのこどもたちの個性を活かし、未来をより良くする社会の実現を目指します。',
+  },
   alternates: { canonical: '/about' },
 };
 
@@ -47,7 +52,13 @@ const ORG_INFO_ITEMS = [
 ] as const;
 
 export default async function Page() {
-  const membersData = await getMembersList();
+  let members: Member[] = [];
+  try {
+    const membersData = await getMembersList();
+    members = membersData.contents;
+  } catch {
+    // メンバー取得に失敗してもページは表示する
+  }
 
   return (
     <>
@@ -106,9 +117,9 @@ export default async function Page() {
       <MissionSection />
 
       {/* メンバーセクション */}
-      {membersData.contents.length > 0 && (
+      {members.length > 0 && (
         <ScrollReveal>
-          <MemberCarousel members={membersData.contents} />
+          <MemberCarousel members={members} />
         </ScrollReveal>
       )}
 

--- a/app/activities/p/[current]/page.tsx
+++ b/app/activities/p/[current]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { getReportsList, getCategoryList } from '@/app/_libs/microcms';
 import { REPORTS_LIST_LIMIT, TOP_CATEGORY_NAMES } from '@/app/_constants';
 import type { Category } from '@/app/_libs/microcms';
@@ -15,6 +16,47 @@ type Props = {
   }>;
   searchParams: Promise<{ category?: string }>;
 };
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const [params, searchParams] = await Promise.all([props.params, props.searchParams]);
+  const current = parseInt(params.current, 10);
+  const categoryParam = searchParams.category;
+  const selectedIds = categoryParam ? categoryParam.split(',').filter(Boolean) : [];
+
+  let categoryLabel = '';
+  if (selectedIds.length > 0) {
+    try {
+      const categoriesData = await getCategoryList();
+      const activeNames = categoriesData.contents
+        .filter((cat) => selectedIds.includes(cat.id))
+        .map((cat) => cat.name);
+      if (activeNames.length > 0) {
+        categoryLabel = activeNames.join('・');
+      }
+    } catch {
+      // fallthrough to default
+    }
+  }
+
+  const pageTitle = categoryLabel
+    ? `${categoryLabel}の活動レポート（${current}ページ目）`
+    : `活動レポート（${current}ページ目）`;
+  const pageDescription = categoryLabel
+    ? `放課後こどもラボの「${categoryLabel}」に関する活動レポート一覧の${current}ページ目です。`
+    : `放課後こどもラボの活動レポート一覧の${current}ページ目です。`;
+
+  return {
+    title: pageTitle,
+    description: pageDescription,
+    openGraph: {
+      title: pageTitle,
+      description: pageDescription,
+    },
+    alternates: {
+      canonical: current === 1 ? '/activities' : `/activities/p/${current}`,
+    },
+  };
+}
 
 export default async function Page(props: Props) {
   const [params, searchParams] = await Promise.all([props.params, props.searchParams]);

--- a/app/activities/page.tsx
+++ b/app/activities/page.tsx
@@ -27,9 +27,15 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
 
       if (activeNames.length > 0) {
         const joined = activeNames.join('・');
+        const catTitle = `${joined}の活動レポート`;
+        const catDescription = `放課後こどもラボの「${joined}」に関する活動レポート一覧です。`;
         return {
-          title: `${joined}の活動レポート`,
-          description: `放課後こどもラボの「${joined}」に関する活動レポート一覧です。`,
+          title: catTitle,
+          description: catDescription,
+          openGraph: {
+            title: catTitle,
+            description: catDescription,
+          },
           alternates: { canonical: '/activities' },
         };
       }
@@ -42,6 +48,11 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
     title: '活動内容',
     description:
       '放課後こどもラボの活動レポート一覧。ものづくり・実験・プログラミング・自然活動など、こどもたちの創造的な学びの記録です。',
+    openGraph: {
+      title: '活動内容',
+      description:
+        '放課後こどもラボの活動レポート一覧。ものづくり・実験・プログラミング・自然活動など、こどもたちの創造的な学びの記録です。',
+    },
     alternates: { canonical: '/activities' },
   };
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,5 +1,18 @@
+import { Metadata } from 'next';
 import styles from './page.module.css';
 import ContactForm from '@/app/_components/ContactForm';
+
+export const metadata: Metadata = {
+  title: 'お問い合わせ',
+  description:
+    'NPO法人PLDL（放課後こどもラボ）へのお問い合わせフォーム。活動に関するご質問やご相談を受け付けています。',
+  openGraph: {
+    title: 'お問い合わせ',
+    description:
+      'NPO法人PLDL（放課後こどもラボ）へのお問い合わせフォーム。活動に関するご質問やご相談を受け付けています。',
+  },
+  alternates: { canonical: '/contact' },
+};
 
 export default function Page() {
   return (

--- a/app/error.module.css
+++ b/app/error.module.css
@@ -1,0 +1,68 @@
+.content {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-4);
+}
+
+.illustration {
+  width: 200px;
+  height: auto;
+  margin-bottom: var(--spacing-4);
+}
+
+.title {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  text-align: center;
+  color: var(--color-text-primary);
+}
+
+.text {
+  font-size: var(--font-size-md);
+  text-align: center;
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-relaxed);
+}
+
+.actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-4);
+  margin-top: var(--spacing-6);
+}
+
+.retryButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 12px 32px;
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-primary);
+  background: transparent;
+  border: 2px solid var(--color-primary);
+  border-radius: var(--border-radius-full);
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s;
+}
+
+.retryButton:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+@media (max-width: 640px) {
+  .illustration {
+    width: 160px;
+  }
+
+  .title {
+    font-size: var(--font-size-xl);
+  }
+
+  .text {
+    text-align: left;
+  }
+}

--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import Image from 'next/image';
+import Sheet from '@/app/_components/Sheet';
+import ButtonLink from '@/app/_components/ButtonLink';
+import styles from './error.module.css';
+
+export default function Error({ reset }: { error: Error; reset: () => void }) {
+  return (
+    <Sheet>
+      <div className={styles.content}>
+        <Image
+          src="/images/assets/404.webp"
+          alt="エラーが発生しました"
+          width={200}
+          height={200}
+          className={styles.illustration}
+        />
+        <h2 className={styles.title}>エラーが発生しました</h2>
+        <p className={styles.text}>
+          ページの読み込み中に問題が発生しました。
+          <br />
+          時間をおいて再度お試しください。
+        </p>
+        <div className={styles.actions}>
+          <button type="button" className={styles.retryButton} onClick={reset}>
+            再試行する
+          </button>
+          <ButtonLink href="/">トップページへ戻る</ButtonLink>
+        </div>
+      </div>
+    </Sheet>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Zen_Kaku_Gothic_New } from 'next/font/google';
 import { getMeta } from '@/app/_libs/microcms';
 import {
   SITE_NAME,
+  SITE_TITLE,
   SITE_DESCRIPTION,
   DEFAULT_OG_IMAGE,
   DEFAULT_OG_IMAGE_FALLBACK,
@@ -24,7 +25,7 @@ export async function generateMetadata(): Promise<Metadata> {
   const baseUrl = process.env.BASE_URL || 'http://localhost:3000';
   const data = await getMeta();
 
-  const title = data?.title || SITE_NAME;
+  const title = data?.title || SITE_TITLE;
   const description = data?.description || SITE_DESCRIPTION;
   const ogImages = data?.ogImage?.url
     ? [{ url: data.ogImage.url }]

--- a/app/privacy-policy/page.tsx
+++ b/app/privacy-policy/page.tsx
@@ -1,4 +1,17 @@
+import { Metadata } from 'next';
 import styles from './page.module.css';
+
+export const metadata: Metadata = {
+  title: 'プライバシーポリシー',
+  description:
+    'NPO法人PLDL（放課後こどもラボ）のプライバシーポリシー。個人情報の収集・利用・管理について定めています。',
+  openGraph: {
+    title: 'プライバシーポリシー',
+    description:
+      'NPO法人PLDL（放課後こどもラボ）のプライバシーポリシー。個人情報の収集・利用・管理について定めています。',
+  },
+  alternates: { canonical: '/privacy-policy' },
+};
 
 export default function Page() {
   return (

--- a/app/recruit/page.tsx
+++ b/app/recruit/page.tsx
@@ -9,6 +9,11 @@ export const metadata: Metadata = {
   title: 'PLDLではたらくということ',
   description:
     'NPO法人PLDLで働く意義。こどもたちの未来をより良くすること、自分のスキルを還元すること、教育における社会課題解決に寄与すること。ボランティアからスタッフへのステップアップ制度もあります。',
+  openGraph: {
+    title: 'PLDLではたらくということ',
+    description:
+      'NPO法人PLDLで働く意義。こどもたちの未来をより良くすること、自分のスキルを還元すること、教育における社会課題解決に寄与すること。',
+  },
   alternates: { canonical: '/recruit' },
 };
 

--- a/app/support/donation/page.tsx
+++ b/app/support/donation/page.tsx
@@ -8,6 +8,11 @@ export const metadata: Metadata = {
   title: '寄付で支援する',
   description:
     'NPO法人PLDLへの寄付のご案内。個人・法人どちらからもご寄付いただけます。皆様のご支援が、こどもたちの学びの場を支えます。',
+  openGraph: {
+    title: '寄付で支援する',
+    description:
+      'NPO法人PLDLへの寄付のご案内。個人・法人どちらからもご寄付いただけます。皆様のご支援が、こどもたちの学びの場を支えます。',
+  },
   alternates: { canonical: '/support/donation' },
 };
 

--- a/app/support/material/page.tsx
+++ b/app/support/material/page.tsx
@@ -9,6 +9,11 @@ export const metadata: Metadata = {
   title: '素材で支援する',
   description:
     'こどもたちの創作活動に必要な材料・素材のご提供をお願いしています。木材、布、紙、金属など、あなたの手元にある素材が学びの場を豊かにします。',
+  openGraph: {
+    title: '素材で支援する',
+    description:
+      'こどもたちの創作活動に必要な材料・素材のご提供をお願いしています。木材、布、紙、金属など、あなたの手元にある素材が学びの場を豊かにします。',
+  },
   alternates: { canonical: '/support/material' },
 };
 

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -9,6 +9,11 @@ export const metadata: Metadata = {
   title: 'サポートのお願い',
   description:
     'NPO法人PLDLへのサポート方法のご案内。スキル・素材・ボランティア・寄付の4つの方法で、こどもたちの学びの場を支えてください。',
+  openGraph: {
+    title: 'サポートのお願い',
+    description:
+      'NPO法人PLDLへのサポート方法のご案内。スキル・素材・ボランティア・寄付の4つの方法で、こどもたちの学びの場を支えてください。',
+  },
   alternates: { canonical: '/support' },
 };
 

--- a/app/support/skill/page.tsx
+++ b/app/support/skill/page.tsx
@@ -9,6 +9,11 @@ export const metadata: Metadata = {
   title: 'スキルで支援する',
   description:
     'あなたのスキルやノウハウを、こどもたちの学びに活かしてみませんか。NPO法人PLDLでは個人・法人からのスキル支援を募集しています。',
+  openGraph: {
+    title: 'スキルで支援する',
+    description:
+      'あなたのスキルやノウハウを、こどもたちの学びに活かしてみませんか。NPO法人PLDLでは個人・法人からのスキル支援を募集しています。',
+  },
   alternates: { canonical: '/support/skill' },
 };
 

--- a/app/support/volunteer/page.tsx
+++ b/app/support/volunteer/page.tsx
@@ -9,6 +9,11 @@ export const metadata: Metadata = {
   title: 'ボランティアで支援する',
   description:
     'NPO法人PLDLのボランティア活動に参加しませんか。教育問題に関心がある方、地域貢献をしたい方、非営利組織に興味がある方を歓迎します。',
+  openGraph: {
+    title: 'ボランティアで支援する',
+    description:
+      'NPO法人PLDLのボランティア活動に参加しませんか。教育問題に関心がある方、地域貢献をしたい方、非営利組織に興味がある方を歓迎します。',
+  },
   alternates: { canonical: '/support/volunteer' },
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -28,7 +28,7 @@ const nextConfig = {
             key: 'Content-Security-Policy',
             value: [
               "default-src 'self'",
-              "script-src 'self' 'unsafe-inline'",
+              `script-src 'self' 'unsafe-inline'${process.env.NODE_ENV === 'development' ? " 'unsafe-eval'" : ''}`,
               "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
               "img-src 'self' data: https://images.microcms-assets.io",
               "font-src 'self' https://fonts.gstatic.com",


### PR DESCRIPTION
- SITE_TITLE新設（ホームページ用SEOタイトル、SERP表示幅最適化）
- SITE_DESCRIPTIONに英語正式名（Playful Learning Design Lab.）追加
- 全13ページにopenGraph（title/description）設定追加
- /contact, /privacy-policy, /activities/p/[current] にmetadata新規追加
- ページネーションページに動的generateMetadata追加（canonical正規化含む）
- optimizeImageUrlをmicrocms.tsからutils.tsへ移動
- about/page.tsxのメンバー取得にエラーハンドリング追加
- CSP: 開発環境でunsafe-eval許可
- error.tsx（エラーバウンダリ）新規追加