### PR TITLE
FEAT: トップページにGSAPパララックス効果を追加

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -57,7 +57,9 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
 # Below is the complete list of tools for convenience.
 # To make sure you have the latest list of tools, and to view their descriptions, 
 # execute `uv run scripts/print_tool_overview.py`.
@@ -98,7 +100,8 @@ read_only: false
 #  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
 excluded_tools: []
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
@@ -133,3 +136,17 @@ symbol_info_budget:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/app/_components/ActivitiesReveal/index.tsx
+++ b/app/_components/ActivitiesReveal/index.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import gsap from 'gsap';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function ActivitiesReveal({ children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference)', () => {
+      const title = el.querySelector<HTMLElement>('[data-activities-title]');
+      const description = el.querySelector<HTMLElement>('[data-activities-description]');
+      const cards = el.querySelectorAll<HTMLElement>('[data-activities-card]');
+      const cta = el.querySelector<HTMLElement>('[data-activities-cta]');
+
+      // Initial state
+      if (title) gsap.set(title, { y: 30, opacity: 0 });
+      if (description) gsap.set(description, { y: 30, opacity: 0 });
+      if (cards.length > 0) gsap.set(cards, { y: 40, opacity: 0 });
+      if (cta) gsap.set(cta, { y: 20, opacity: 0 });
+
+      // IntersectionObserver — fire once
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+
+          const tl = gsap.timeline();
+
+          if (title) {
+            tl.to(title, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0);
+          }
+          if (description) {
+            tl.to(description, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0.15);
+          }
+          if (cards.length > 0) {
+            tl.to(
+              cards,
+              { y: 0, opacity: 1, duration: 0.7, ease: 'power2.out', stagger: 0.15 },
+              0.35,
+            );
+          }
+          if (cta) {
+            tl.to(cta, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.7);
+          }
+        },
+        { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+      );
+
+      observer.observe(el);
+
+      return () => {
+        observer.disconnect();
+      };
+    });
+
+    mm.add('(prefers-reduced-motion: reduce)', () => {
+      const targets = el.querySelectorAll<HTMLElement>(
+        '[data-activities-title], [data-activities-description], [data-activities-card], [data-activities-cta]',
+      );
+      targets.forEach((target) => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+      });
+    });
+
+    return () => mm.revert();
+  }, []);
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/app/_components/CtaReveal/index.tsx
+++ b/app/_components/CtaReveal/index.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import { usePathname } from 'next/navigation';
+import gsap from 'gsap';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function CtaReveal({ children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference)', () => {
+      const bg = el.querySelector<HTMLElement>('[data-cta-bg]');
+      const heading = el.querySelector<HTMLElement>('[data-cta-heading]');
+      const text = el.querySelector<HTMLElement>('[data-cta-text]');
+      const button = el.querySelector<HTMLElement>('[data-cta-button]');
+
+      // Initial state — background collapsed, content hidden
+      if (bg) gsap.set(bg, { clipPath: 'inset(0% 50% 0% 50%)', opacity: 1 });
+      if (heading) gsap.set(heading, { y: 30, opacity: 0 });
+      if (text) gsap.set(text, { y: 20, opacity: 0 });
+      if (button) gsap.set(button, { y: 15, opacity: 0 });
+
+      // IntersectionObserver — fire once
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+
+          const tl = gsap.timeline();
+
+          // Phase 1: Background reveal
+          if (bg) {
+            tl.to(bg, {
+              clipPath: 'inset(0% 0% 0% 0%)',
+              duration: 0.8,
+              ease: 'power3.inOut',
+            }, 0);
+          }
+
+          // Phase 2: Content fade-in (starts while bg is still finishing)
+          if (heading) {
+            tl.to(heading, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0.5);
+          }
+          if (text) {
+            tl.to(text, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.7);
+          }
+          if (button) {
+            tl.to(button, { y: 0, opacity: 1, duration: 0.5, ease: 'back.out(1.7)' }, 0.9);
+          }
+        },
+        { threshold: 0.2, rootMargin: '0px 0px -40px 0px' },
+      );
+
+      observer.observe(el);
+
+      return () => {
+        observer.disconnect();
+      };
+    });
+
+    mm.add('(prefers-reduced-motion: reduce)', () => {
+      const targets = el.querySelectorAll<HTMLElement>(
+        '[data-cta-bg], [data-cta-heading], [data-cta-text], [data-cta-button]',
+      );
+      targets.forEach((target) => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+        target.style.clipPath = 'none';
+      });
+    });
+
+    return () => mm.revert();
+  }, [pathname]);
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/app/_components/Footer/index.tsx
+++ b/app/_components/Footer/index.tsx
@@ -25,7 +25,7 @@ const NAV_GROUPS = [
 const SOCIALS = [
   { href: 'https://x.com/', icon: Twitter, label: 'X' },
   { href: 'https://facebook.com/', icon: Facebook, label: 'Facebook' },
-  { href: 'https://instagram.com/', icon: Instagram, label: 'Instagram' },
+  { href: 'https://www.instagram.com/playful_learning_design_lab/', icon: Instagram, label: 'Instagram' },
 ];
 
 export default function Footer() {

--- a/app/_components/Footer/index.tsx
+++ b/app/_components/Footer/index.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { Twitter, Facebook, Instagram } from 'lucide-react';
 import FooterLogo from './FooterLogo';
+import CtaReveal from '../CtaReveal';
 import styles from './index.module.css';
 
 const NAV_GROUPS = [
@@ -32,25 +33,27 @@ export default function Footer() {
   return (
     <footer className={styles.footer}>
       {/* CTA セクション */}
-      <section className={styles.cta}>
-        <div className={styles.ctaInner}>
-          <h2 className={styles.ctaHeading}>
-            こどもの未来を、
-            <br />
-            一緒につくりませんか？
-          </h2>
-          <div className={styles.ctaAction}>
-            <p className={styles.ctaText}>
-              活動への参加・ご支援・お仕事のご相談など、
-              <br className={styles.brDesktop} />
-              まずはお気軽にご連絡ください。
-            </p>
-            <Link href="/contact" className={styles.ctaButton}>
-              お問い合わせはこちら
-            </Link>
+      <CtaReveal>
+        <section className={styles.cta} data-cta-bg>
+          <div className={styles.ctaInner}>
+            <h2 className={styles.ctaHeading} data-cta-heading>
+              こどもの未来を、
+              <br />
+              一緒につくりませんか？
+            </h2>
+            <div className={styles.ctaAction}>
+              <p className={styles.ctaText} data-cta-text>
+                活動への参加・ご支援・お仕事のご相談など、
+                <br className={styles.brDesktop} />
+                まずはお気軽にご連絡ください。
+              </p>
+              <Link href="/contact" className={styles.ctaButton} data-cta-button>
+                お問い合わせはこちら
+              </Link>
+            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      </CtaReveal>
 
       {/* Footer 本体 */}
       <div className={styles.body}>

--- a/app/_components/Hero/BlobReveal.tsx
+++ b/app/_components/Hero/BlobReveal.tsx
@@ -26,6 +26,7 @@ export default function BlobReveal({ children, className }: Props) {
         {
           clipPath: 'circle(100% at 50% 50%)',
           duration: 3.0,
+          delay: 0.5,
           ease: 'expo.out',
           onComplete: () => {
             el.style.removeProperty('clip-path');

--- a/app/_components/Hero/ShowcaseReveal.tsx
+++ b/app/_components/Hero/ShowcaseReveal.tsx
@@ -21,7 +21,7 @@ export default function ShowcaseReveal({ children }: Props) {
       const content = el.querySelector('[data-showcase-content]');
       const bottom = el.querySelector('[data-showcase-bottom]');
 
-      const tl = gsap.timeline();
+      const tl = gsap.timeline({ delay: 0.5 });
 
       if (image) {
         tl.fromTo(

--- a/app/_components/Hero/index.tsx
+++ b/app/_components/Hero/index.tsx
@@ -178,7 +178,7 @@ export default function Hero(props: Props) {
                 <span
                   key={i}
                   className={styles.char}
-                  style={{ animationDelay: `${200 + i * 40}ms` }}
+                  style={{ animationDelay: `${700 + i * 40}ms` }}
                 >
                   {char}
                 </span>
@@ -192,7 +192,7 @@ export default function Hero(props: Props) {
                 <span
                   key={i}
                   className={styles.char}
-                  style={{ animationDelay: `${750 + i * 40}ms` }}
+                  style={{ animationDelay: `${1250 + i * 40}ms` }}
                 >
                   {char === ' ' ? '\u00A0' : char}
                 </span>

--- a/app/_components/IntroSection/index.tsx
+++ b/app/_components/IntroSection/index.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import Image from 'next/image';
+import ButtonLink from '@/app/_components/ButtonLink';
+import styles from '../../about/page.module.css';
+
+export default function IntroSection() {
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    let cleanup: (() => void) | undefined;
+
+    (async () => {
+      const { default: gsap } = await import('gsap');
+      const mm = gsap.matchMedia();
+
+      mm.add('(prefers-reduced-motion: no-preference)', () => {
+        const title = el.querySelector<HTMLElement>('[data-intro-title]');
+        const descriptions = el.querySelectorAll<HTMLElement>('[data-intro-desc]');
+        const button = el.querySelector<HTMLElement>('[data-intro-button]');
+        const image = el.querySelector<HTMLElement>('[data-intro-image]');
+
+        // Initial hidden state
+        if (title) gsap.set(title, { y: 30, opacity: 0 });
+        if (descriptions.length > 0) gsap.set(descriptions, { y: 20, opacity: 0 });
+        if (button) gsap.set(button, { y: 20, opacity: 0 });
+        if (image) gsap.set(image, { scale: 0.85, opacity: 0 });
+
+        const observer = new IntersectionObserver(
+          ([entry]) => {
+            if (!entry.isIntersecting) return;
+            observer.disconnect();
+
+            const tl = gsap.timeline();
+            const isMobile = window.matchMedia('(max-width: 768px)').matches;
+
+            if (isMobile) {
+              // Mobile: image first (column-reverse layout)
+              if (image) {
+                tl.to(image, { scale: 1, opacity: 1, duration: 0.7, ease: 'power2.out' }, 0);
+              }
+              if (title) {
+                tl.to(title, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0.3);
+              }
+              if (descriptions.length > 0) {
+                tl.to(
+                  descriptions,
+                  { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out', stagger: 0.12 },
+                  0.5,
+                );
+              }
+              if (button) {
+                const descEnd = 0.5 + 0.5 + (descriptions.length - 1) * 0.12;
+                tl.to(
+                  button,
+                  { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' },
+                  descEnd + 0.1,
+                );
+              }
+            } else {
+              // Desktop: text left + image right simultaneously
+              if (title) {
+                tl.to(title, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0);
+              }
+              if (descriptions.length > 0) {
+                tl.to(
+                  descriptions,
+                  { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out', stagger: 0.12 },
+                  0.2,
+                );
+              }
+              if (button) {
+                const descEnd = 0.2 + 0.5 + (descriptions.length - 1) * 0.12;
+                tl.to(
+                  button,
+                  { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' },
+                  descEnd + 0.1,
+                );
+              }
+              if (image) {
+                tl.to(
+                  image,
+                  { scale: 1, opacity: 1, duration: 0.7, ease: 'power2.out' },
+                  0.15,
+                );
+              }
+            }
+          },
+          { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+        );
+
+        observer.observe(el);
+        return () => observer.disconnect();
+      });
+
+      mm.add('(prefers-reduced-motion: reduce)', () => {
+        const targets = el.querySelectorAll<HTMLElement>(
+          '[data-intro-title], [data-intro-desc], [data-intro-button], [data-intro-image]',
+        );
+        targets.forEach((target) => {
+          target.style.opacity = '1';
+          target.style.transform = 'none';
+        });
+      });
+
+      cleanup = () => mm.revert();
+    })();
+
+    return () => cleanup?.();
+  }, []);
+
+  return (
+    <section ref={sectionRef} className={styles.intro}>
+      <div className={styles.introContainer}>
+        <div className={styles.introText}>
+          <h2 className={styles.introTitle} data-intro-title>
+            ワクワクする学びが
+            <br />
+            こどもたちの未来を創る
+          </h2>
+          <p className={styles.introDescription} data-intro-desc>
+            「知らないことを知ることは楽しい」
+            <br />
+            学びとは本来ワクワクするものです。
+            <br />
+            私たちは「学びのワクワク」を様々なプロジェクトを
+            <br />
+            通じて、こどもたちに伝えていきます。
+          </p>
+          <p className={styles.introDescription} data-intro-desc>
+            学ぶことの楽しさを知った子どもたちは
+            <br />
+            自分で考え、行動し、自分の未来を切り拓くことが
+            <br />
+            できると信じています。
+          </p>
+          <p className={styles.introDescription} data-intro-desc>
+            NPO法人PLDLでは、様々なワクワクの場を
+            <br />
+            デザインしていきます。
+          </p>
+          <div data-intro-button>
+            <ButtonLink href="/activities">PLDLについて</ButtonLink>
+          </div>
+        </div>
+        <div className={styles.introImageWrap} data-intro-image>
+          <Image
+            src="/photos/boys-sawing-branch-outdoor.webp"
+            alt="活動の様子"
+            width={480}
+            height={480}
+            className={styles.introImage}
+            sizes="(max-width: 640px) 200px, (max-width: 768px) 260px, 360px"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/_components/MemberCarousel/index.tsx
+++ b/app/_components/MemberCarousel/index.tsx
@@ -3,6 +3,7 @@
 import { useRef, useState, useCallback, useEffect } from 'react';
 import Image from 'next/image';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
+import gsap from 'gsap';
 import type { Member } from '@/app/_libs/microcms';
 import { optimizeImageUrl, extractName } from '@/app/_libs/utils';
 import styles from './index.module.css';
@@ -19,6 +20,7 @@ function stripHtml(html: string): string {
 }
 
 export default function MemberCarousel({ members }: Props) {
+  const sectionRef = useRef<HTMLElement>(null);
   const trackRef = useRef<HTMLDivElement>(null);
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(true);
@@ -44,6 +46,78 @@ export default function MemberCarousel({ members }: Props) {
     };
   }, [updateScrollState]);
 
+  // GSAP scroll-triggered animation
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference)', () => {
+      const accent = el.querySelector<HTMLElement>('[data-member-accent]');
+      const subEn = el.querySelector<HTMLElement>('[data-member-sub-en]');
+      const heading = el.querySelector<HTMLElement>('[data-member-heading]');
+      const description = el.querySelector<HTMLElement>('[data-member-description]');
+      const cards = el.querySelectorAll<HTMLElement>('[data-member-card]');
+      const navButtons = el.querySelectorAll<HTMLElement>('[data-member-nav]');
+
+      // Initial hidden state
+      if (accent) gsap.set(accent, { scaleX: 0, transformOrigin: 'left center' });
+      const textTargets = [subEn, heading, description].filter(Boolean) as HTMLElement[];
+      gsap.set(textTargets, { y: 20, opacity: 0 });
+      if (cards.length > 0) gsap.set(cards, { y: 40, opacity: 0 });
+      if (navButtons.length > 0) gsap.set(navButtons, { opacity: 0 });
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+
+          const tl = gsap.timeline();
+
+          if (accent) {
+            tl.to(accent, { scaleX: 1, duration: 0.5, ease: 'power2.out' }, 0);
+          }
+          if (subEn) {
+            tl.to(subEn, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.15);
+          }
+          if (heading) {
+            tl.to(heading, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.25);
+          }
+          if (description) {
+            tl.to(description, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.35);
+          }
+          if (cards.length > 0) {
+            tl.to(
+              cards,
+              { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out', stagger: 0.08 },
+              0.45,
+            );
+          }
+          if (navButtons.length > 0) {
+            tl.to(navButtons, { opacity: 1, duration: 0.4, ease: 'power2.out' }, 0.7);
+          }
+        },
+        { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+      );
+
+      observer.observe(el);
+      return () => observer.disconnect();
+    });
+
+    mm.add('(prefers-reduced-motion: reduce)', () => {
+      const targets = el.querySelectorAll<HTMLElement>(
+        '[data-member-accent], [data-member-sub-en], [data-member-heading], [data-member-description], [data-member-card], [data-member-nav]',
+      );
+      targets.forEach((target) => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+      });
+    });
+
+    return () => mm.revert();
+  }, []);
+
   const scroll = (direction: 'left' | 'right') => {
     const track = trackRef.current;
     if (!track) return;
@@ -56,12 +130,12 @@ export default function MemberCarousel({ members }: Props) {
   if (members.length === 0) return null;
 
   return (
-    <section className={styles.section}>
+    <section ref={sectionRef} className={styles.section}>
       <div className={styles.container}>
-        <div className={styles.accent} />
-        <p className={styles.subEn}>Member</p>
-        <h2 className={styles.heading}>メンバー紹介</h2>
-        <p className={styles.description}>
+        <div className={styles.accent} data-member-accent />
+        <p className={styles.subEn} data-member-sub-en>Member</p>
+        <h2 className={styles.heading} data-member-heading>メンバー紹介</h2>
+        <p className={styles.description} data-member-description>
           PLDLで活動するメンバーをご紹介します。
           <br />
           それぞれの専門性を活かし、こどもたちの学びの場を創っています。
@@ -75,6 +149,7 @@ export default function MemberCarousel({ members }: Props) {
           onClick={() => scroll('left')}
           disabled={!canScrollLeft}
           aria-label="前のメンバーへ"
+          data-member-nav
         >
           <ChevronLeft size={24} />
         </button>
@@ -85,7 +160,7 @@ export default function MemberCarousel({ members }: Props) {
               const displayName = extractName(member.name);
               const comment = member.content ? stripHtml(member.content) : '';
               return (
-                <article key={member.id} className={styles.card}>
+                <article key={member.id} className={styles.card} data-member-card>
                   <div className={styles.cardImageWrap}>
                     <Image
                       src={member.thumbnail ? optimizeImageUrl(member.thumbnail.url, 560) : '/ogp.webp'}
@@ -124,6 +199,7 @@ export default function MemberCarousel({ members }: Props) {
           onClick={() => scroll('right')}
           disabled={!canScrollRight}
           aria-label="次のメンバーへ"
+          data-member-nav
         >
           <ChevronRight size={24} />
         </button>

--- a/app/_components/MessageSection/index.tsx
+++ b/app/_components/MessageSection/index.tsx
@@ -1,0 +1,176 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import Image from 'next/image';
+import gsap from 'gsap';
+import styles from '../../about/page.module.css';
+
+export default function MessageSection() {
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference)', () => {
+      const accent = el.querySelector<HTMLElement>('[data-message-accent]');
+      const subEn = el.querySelector<HTMLElement>('[data-message-sub-en]');
+      const heading = el.querySelector<HTMLElement>('[data-message-heading]');
+      const imageMobile = el.querySelector<HTMLElement>('[data-message-image-mobile]');
+      const bodyParagraphs = el.querySelectorAll<HTMLElement>('[data-message-body-p]');
+      const signature = el.querySelector<HTMLElement>('[data-message-signature]');
+      const imageDesktop = el.querySelector<HTMLElement>('[data-message-image]');
+
+      // Initial hidden state
+      if (accent) gsap.set(accent, { scaleX: 0, transformOrigin: 'left center' });
+      const fadeUpTargets = [subEn, heading].filter(Boolean) as HTMLElement[];
+      gsap.set(fadeUpTargets, { y: 20, opacity: 0 });
+      if (imageMobile) gsap.set(imageMobile, { scale: 0.85, opacity: 0 });
+      if (bodyParagraphs.length > 0) gsap.set(bodyParagraphs, { y: 20, opacity: 0 });
+      if (signature) gsap.set(signature, { y: 20, opacity: 0 });
+      if (imageDesktop) gsap.set(imageDesktop, { scale: 0.85, opacity: 0 });
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+
+          const tl = gsap.timeline();
+          const isDesktop = window.matchMedia('(min-width: 921px)').matches;
+
+          // Accent bar: scaleX 0→1
+          if (accent) {
+            tl.to(accent, { scaleX: 1, duration: 0.5, ease: 'power2.out' }, 0);
+          }
+          // SubEn ("Message")
+          if (subEn) {
+            tl.to(subEn, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.15);
+          }
+          // Heading ("代表のメッセージ")
+          if (heading) {
+            tl.to(heading, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.25);
+          }
+          // Mobile image (920px以下のみ表示)
+          if (imageMobile && !isDesktop) {
+            tl.to(
+              imageMobile,
+              { scale: 1, opacity: 1, duration: 0.6, ease: 'power2.out' },
+              0.35,
+            );
+          }
+          // Body paragraphs (staggered)
+          if (bodyParagraphs.length > 0) {
+            tl.to(
+              bodyParagraphs,
+              {
+                y: 0,
+                opacity: 1,
+                duration: 0.5,
+                ease: 'power2.out',
+                stagger: 0.1,
+              },
+              isDesktop ? 0.35 : 0.55,
+            );
+          }
+          // Signature (body完了後+0.1s)
+          if (signature) {
+            const bodyEnd =
+              (isDesktop ? 0.35 : 0.55) + 0.5 + (bodyParagraphs.length - 1) * 0.1;
+            tl.to(
+              signature,
+              { y: 0, opacity: 1, duration: 0.4, ease: 'power2.out' },
+              bodyEnd + 0.1,
+            );
+          }
+          // Desktop image (920px超のみ)
+          if (imageDesktop && isDesktop) {
+            tl.to(
+              imageDesktop,
+              { scale: 1, opacity: 1, duration: 0.7, ease: 'power2.out' },
+              0.2,
+            );
+          }
+        },
+        { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+      );
+
+      observer.observe(el);
+      return () => observer.disconnect();
+    });
+
+    mm.add('(prefers-reduced-motion: reduce)', () => {
+      const targets = el.querySelectorAll<HTMLElement>(
+        '[data-message-accent], [data-message-sub-en], [data-message-heading], [data-message-image-mobile], [data-message-body-p], [data-message-signature], [data-message-image]',
+      );
+      targets.forEach((target) => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+      });
+    });
+
+    return () => mm.revert();
+  }, []);
+
+  return (
+    <section ref={sectionRef} className={styles.messageSection}>
+      <div className={styles.messageContainer}>
+        <div className={styles.messageText}>
+          <div className={styles.messageAccent} data-message-accent />
+          <p className={styles.messageSubEn} data-message-sub-en>
+            Message
+          </p>
+          <h2 className={styles.messageHeading} data-message-heading>
+            代表のメッセージ
+          </h2>
+          <div className={styles.messageImageMobile} data-message-image-mobile>
+            <Image
+              src="/images/assets/matsushima-sakiko.webp"
+              alt="代表理事 松島咲季子"
+              width={280}
+              height={280}
+              className={styles.messageImageCircle}
+              sizes="200px"
+            />
+          </div>
+          <div className={styles.messageBody}>
+            <p data-message-body-p>
+              はじめてこどもたちとワークショップをした日、こどもたちは
+              想像をはるかに超える創造力と好奇心で私を圧倒してくれました。
+            </p>
+            <p data-message-body-p>
+              成長していく中で環境や一部の評価などを理由に
+              学びからドロップアウトしてしまうこどもが多いのが現状です。
+              しかし、私はあの日、すべてのこどもたちは平等に素晴らしい力を持っていて
+              その力さえ引き出せれば、創造力と好奇心と、そして強い意志をもって
+              未来を切り開いていくことができると実感しました。
+            </p>
+            <p data-message-body-p>
+              私たちは、学ぶことは楽しい、知らないことを知ることは面白いことというポジティブな
+              マインドをもったこどもを一人でも増やしたいという思いでこの事業を立ち上げました。
+            </p>
+            <p data-message-body-p>
+              環境や経済状況に関わらず自らの力と意志で自分の未来を切り開いてくれるこどもが
+              増えることを目指して私たちはこどもたちの「したい！」「知りたい！」を全力でサポートし続けます。
+            </p>
+          </div>
+          <div className={styles.messageSignature} data-message-signature>
+            <span className={styles.signatureRole}>代表理事</span>
+            <span className={styles.signatureName}>松島咲季子</span>
+          </div>
+        </div>
+        <div className={styles.messageImageWrap} data-message-image>
+          <Image
+            src="/images/assets/matsushima-sakiko.webp"
+            alt="代表理事 松島咲季子"
+            width={400}
+            height={400}
+            className={styles.messageImage}
+            sizes="(max-width: 920px) 100vw, 350px"
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/_components/MissionSection/index.module.css
+++ b/app/_components/MissionSection/index.module.css
@@ -1,5 +1,5 @@
 .section {
-  padding: 100px 0;
+  padding: 130px 0;
   background: var(--color-primary);
   overflow: clip;
 }

--- a/app/_components/MissionSection/index.tsx
+++ b/app/_components/MissionSection/index.tsx
@@ -7,22 +7,24 @@ export default function MissionSection() {
       <section className={styles.section} id="mission">
         <div className={styles.container}>
           <div className={styles.horizontal}>
-            <Image
-              src="/photos/kids-daikon-harvest.webp"
-              alt="大根の収穫体験をするこどもたち"
-              width={960}
-              height={960}
-              className={styles.image}
-              sizes="(max-width: 640px) 100vw, 420px"
-            />
-            <div className={styles.textArea}>
-              <h2 className={styles.headingEn}>Mission</h2>
+            <div data-parallax="image">
+              <Image
+                src="/photos/kids-daikon-harvest.webp"
+                alt="大根の収穫体験をするこどもたち"
+                width={960}
+                height={960}
+                className={styles.image}
+                sizes="(max-width: 640px) 100vw, 420px"
+              />
+            </div>
+            <div className={styles.textArea} data-parallax="text">
+              <h2 className={styles.headingEn} data-parallax="heading">Mission</h2>
               <p className={styles.headingJa}>ミッション</p>
               <p className={styles.description}>
                 PLDLはこどもたちのサードプレイスとなり<br />
                 子供たちの学ぶ意欲を育む&ldquo;場&rdquo;をつくりだします。
               </p>
-              <ol className={styles.missionList}>
+              <ol className={styles.missionList} data-parallax="list">
                 <li>学ぶこと＝楽しいことというマインドを育成します</li>
                 <li>創造的な思考をもって、課題解決に取り組む力を育みます</li>
                 <li>異年齢、多様な大人との関わりをプロデュースします</li>

--- a/app/_components/MissionSection/index.tsx
+++ b/app/_components/MissionSection/index.tsx
@@ -1,13 +1,14 @@
 import Image from 'next/image';
+import SectionReveal from '../SectionReveal';
 import styles from './index.module.css';
 
 export default function MissionSection() {
   return (
     <>
       <section className={styles.section} id="mission">
-        <div className={styles.container}>
-          <div className={styles.horizontal}>
-            <div data-parallax="image">
+        <SectionReveal direction="left">
+          <div className={styles.container}>
+            <div className={styles.horizontal}>
               <Image
                 src="/photos/kids-daikon-harvest.webp"
                 alt="大根の収穫体験をするこどもたち"
@@ -15,25 +16,36 @@ export default function MissionSection() {
                 height={960}
                 className={styles.image}
                 sizes="(max-width: 640px) 100vw, 420px"
+                data-section-image
               />
-            </div>
-            <div className={styles.textArea} data-parallax="text">
-              <h2 className={styles.headingEn} data-parallax="heading">Mission</h2>
-              <p className={styles.headingJa}>ミッション</p>
-              <p className={styles.description}>
-                PLDLはこどもたちのサードプレイスとなり<br />
-                子供たちの学ぶ意欲を育む&ldquo;場&rdquo;をつくりだします。
-              </p>
-              <ol className={styles.missionList} data-parallax="list">
-                <li>学ぶこと＝楽しいことというマインドを育成します</li>
-                <li>創造的な思考をもって、課題解決に取り組む力を育みます</li>
-                <li>異年齢、多様な大人との関わりをプロデュースします</li>
-                <li>こどもたちが自然体でいられる居場所づくりをします</li>
-                <li>経済格差による教育格差を減らします</li>
-              </ol>
+              <div className={styles.textArea}>
+                <h2 className={styles.headingEn} data-section-heading-en>
+                  Mission
+                </h2>
+                <p className={styles.headingJa} data-section-heading-ja>
+                  ミッション
+                </p>
+                <p className={styles.description} data-section-description>
+                  PLDLはこどもたちのサードプレイスとなり<br />
+                  子供たちの学ぶ意欲を育む&ldquo;場&rdquo;をつくりだします。
+                </p>
+                <ol className={styles.missionList}>
+                  <li data-section-list-item>学ぶこと＝楽しいことというマインドを育成します</li>
+                  <li data-section-list-item>
+                    創造的な思考をもって、課題解決に取り組む力を育みます
+                  </li>
+                  <li data-section-list-item>
+                    異年齢、多様な大人との関わりをプロデュースします
+                  </li>
+                  <li data-section-list-item>
+                    こどもたちが自然体でいられる居場所づくりをします
+                  </li>
+                  <li data-section-list-item>経済格差による教育格差を減らします</li>
+                </ol>
+              </div>
             </div>
           </div>
-        </div>
+        </SectionReveal>
       </section>
       <div className={styles.waveBottom} aria-hidden="true">
         <svg className={styles.waveBg} viewBox="0 0 2160 80" preserveAspectRatio="none">

--- a/app/_components/ParallaxSection/index.module.css
+++ b/app/_components/ParallaxSection/index.module.css
@@ -1,0 +1,3 @@
+.wrapper {
+  position: relative;
+}

--- a/app/_components/ParallaxSection/index.tsx
+++ b/app/_components/ParallaxSection/index.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import styles from './index.module.css';
+
+gsap.registerPlugin(ScrollTrigger);
+
+const SPEED_MAP: Record<string, number> = {
+  heading: -60,
+  image: -80,
+  decoration: -50,
+  text: -20,
+  list: -10,
+};
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function ParallaxSection({ children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference) and (min-width: 769px)', () => {
+      const targets = el.querySelectorAll<HTMLElement>('[data-parallax]');
+
+      targets.forEach((target) => {
+        const key = target.dataset.parallax ?? '';
+        const custom = target.dataset.parallaxSpeed;
+        const yValue = custom ? Number(custom) : (SPEED_MAP[key] ?? -20);
+
+        gsap.to(target, {
+          y: yValue,
+          ease: 'none',
+          scrollTrigger: {
+            trigger: el,
+            start: 'top bottom',
+            end: 'bottom top',
+            scrub: 0.5,
+          },
+        });
+      });
+    });
+
+    return () => {
+      mm.revert();
+    };
+  }, []);
+
+  return (
+    <div ref={ref} className={styles.wrapper}>
+      {children}
+    </div>
+  );
+}

--- a/app/_components/PlaceSection/index.tsx
+++ b/app/_components/PlaceSection/index.tsx
@@ -1,0 +1,163 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import Image from 'next/image';
+import styles from '../../about/page.module.css';
+
+const ORG_INFO_ITEMS = [
+  { term: '名称', description: 'NPO法人 Playful Learning Design Lab.' },
+  { term: '設立', description: '2022年10月' },
+  { term: '代表理事', description: '尾池咲季子（松島）' },
+  { term: '理事', description: '近藤隼人　浦田充起' },
+  { term: '監事', description: '新井雄一　アライ商会株式会社 代表取締役' },
+  { term: '所在地', description: '〒379-2313 群馬県みどり市笠懸町鹿3616-1' },
+] as const;
+
+export default function PlaceSection() {
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    let cleanup: (() => void) | undefined;
+
+    (async () => {
+      const { default: gsap } = await import('gsap');
+      const mm = gsap.matchMedia();
+
+      mm.add('(prefers-reduced-motion: no-preference)', () => {
+        const accent = el.querySelector<HTMLElement>('[data-place-accent]');
+        const subEn = el.querySelector<HTMLElement>('[data-place-sub-en]');
+        const heading = el.querySelector<HTMLElement>('[data-place-heading]');
+        const desc = el.querySelector<HTMLElement>('[data-place-desc]');
+        const infoRows = el.querySelectorAll<HTMLElement>('[data-place-info-row]');
+        const image = el.querySelector<HTMLElement>('[data-place-image]');
+        const map = el.querySelector<HTMLElement>('[data-place-map]');
+
+        // Initial hidden state
+        if (accent) gsap.set(accent, { scaleX: 0, transformOrigin: 'left center', opacity: 1 });
+        const fadeUpTargets = [subEn, heading, desc].filter(Boolean) as HTMLElement[];
+        gsap.set(fadeUpTargets, { y: 20, opacity: 0 });
+        if (infoRows.length > 0) gsap.set(infoRows, { y: 15, opacity: 0 });
+        if (map) gsap.set(map, { opacity: 0 });
+
+        const observer = new IntersectionObserver(
+          ([entry]) => {
+            if (!entry.isIntersecting) return;
+            observer.disconnect();
+
+            const tl = gsap.timeline();
+            const isDesktop = window.matchMedia('(min-width: 921px)').matches;
+
+            // Text stagger (same for desktop and mobile)
+            if (accent) tl.to(accent, { scaleX: 1, duration: 0.5, ease: 'power2.out' }, 0);
+            if (subEn)
+              tl.to(subEn, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.15);
+            if (heading)
+              tl.to(heading, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.25);
+            if (desc)
+              tl.to(desc, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.35);
+
+            // orgInfo rows stagger
+            if (infoRows.length > 0) {
+              tl.to(
+                infoRows,
+                { y: 0, opacity: 1, duration: 0.4, ease: 'power2.out', stagger: 0.08 },
+                0.45,
+              );
+            }
+
+            // Desktop: image right clipPath reveal
+            if (image && isDesktop) {
+              gsap.set(image, { clipPath: 'inset(0 0 0 100%)', scale: 1.05, opacity: 1 });
+              tl.to(
+                image,
+                {
+                  clipPath: 'inset(0 0 0 0%)',
+                  scale: 1,
+                  duration: 0.9,
+                  ease: 'power3.out',
+                  onComplete: () => { image.style.removeProperty('clip-path'); },
+                },
+                0.15,
+              );
+            }
+
+            // Map fade-in after orgInfo completes
+            if (map) {
+              const orgInfoEnd = 0.45 + 0.4 + (infoRows.length - 1) * 0.08;
+              tl.to(map, { opacity: 1, duration: 0.6, ease: 'power2.out' }, orgInfoEnd + 0.2);
+            }
+          },
+          { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+        );
+
+        observer.observe(el);
+        return () => observer.disconnect();
+      });
+
+      mm.add('(prefers-reduced-motion: reduce)', () => {
+        const targets = el.querySelectorAll<HTMLElement>(
+          '[data-place-accent], [data-place-sub-en], [data-place-heading], [data-place-desc], [data-place-info-row], [data-place-image], [data-place-map]',
+        );
+        targets.forEach((target) => {
+          target.style.opacity = '1';
+          target.style.transform = 'none';
+          target.style.removeProperty('clip-path');
+        });
+      });
+
+      cleanup = () => mm.revert();
+    })();
+
+    return () => cleanup?.();
+  }, []);
+
+  return (
+    <section ref={sectionRef} className={styles.placeSection}>
+      <div className={styles.placeContainer}>
+        <div className={styles.placeText}>
+          <div className={styles.placeAccent} data-place-accent />
+          <p className={styles.placeSubEn} data-place-sub-en>
+            Place
+          </p>
+          <h2 className={styles.placeHeading} data-place-heading>
+            PLDLの場所
+          </h2>
+          <p className={styles.sectionDescription} data-place-desc>
+            NPO法人PLDLの基本情報をご紹介します。
+          </p>
+          <dl className={styles.orgInfo}>
+            {ORG_INFO_ITEMS.map((item) => (
+              <div key={item.term} className={styles.orgInfoRow} data-place-info-row>
+                <dt className={styles.orgInfoTerm}>{item.term}</dt>
+                <dd className={styles.orgInfoDesc}>{item.description}</dd>
+              </div>
+            ))}
+          </dl>
+        </div>
+        <div className={styles.placeImageWrap} data-place-image>
+          <Image
+            src="/photos/children-walking-outdoor-sunny.webp"
+            alt="晴れた日に歩くこどもたち"
+            width={560}
+            height={420}
+            className={styles.placeImage}
+            sizes="(max-width: 920px) 100vw, 50vw"
+          />
+        </div>
+      </div>
+      <div className={styles.mapWrap} data-place-map>
+        <iframe
+          className={styles.mapIframe}
+          src="https://www.google.com/maps?q=群馬県みどり市笠懸町鹿3616-1&output=embed"
+          title="NPO法人PLDLの所在地"
+          loading="lazy"
+          referrerPolicy="no-referrer-when-downgrade"
+          allowFullScreen
+        />
+      </div>
+    </section>
+  );
+}

--- a/app/_components/RecruitCtaReveal/index.tsx
+++ b/app/_components/RecruitCtaReveal/index.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import gsap from 'gsap';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function RecruitCtaReveal({ children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference)', () => {
+      const lead = el.querySelector<HTMLElement>('[data-rcta-lead]');
+      const heading = el.querySelector<HTMLElement>('[data-rcta-heading]');
+      const button = el.querySelector<HTMLElement>('[data-rcta-button]');
+
+      // Initial hidden state
+      if (lead) gsap.set(lead, { y: 20, opacity: 0 });
+      if (heading) gsap.set(heading, { y: 20, opacity: 0 });
+      if (button) gsap.set(button, { y: 15, opacity: 0 });
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+
+          const tl = gsap.timeline();
+
+          if (lead) tl.to(lead, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0);
+          if (heading)
+            tl.to(heading, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0.15);
+          if (button)
+            tl.to(button, { y: 0, opacity: 1, duration: 0.5, ease: 'back.out(1.7)' }, 0.35);
+        },
+        { threshold: 0.2, rootMargin: '0px 0px -40px 0px' },
+      );
+
+      observer.observe(el);
+
+      return () => {
+        observer.disconnect();
+      };
+    });
+
+    mm.add('(prefers-reduced-motion: reduce)', () => {
+      const targets = el.querySelectorAll<HTMLElement>(
+        '[data-rcta-lead], [data-rcta-heading], [data-rcta-button]',
+      );
+      targets.forEach((target) => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+      });
+    });
+
+    return () => mm.revert();
+  }, []);
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/app/_components/RecruitSection/index.tsx
+++ b/app/_components/RecruitSection/index.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import Image from 'next/image';
+import ButtonLink from '@/app/_components/ButtonLink';
+import styles from '../../about/page.module.css';
+
+export default function RecruitSection() {
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    let cleanup: (() => void) | undefined;
+
+    (async () => {
+      const { default: gsap } = await import('gsap');
+      const mm = gsap.matchMedia();
+
+      mm.add('(prefers-reduced-motion: no-preference)', () => {
+        const image = el.querySelector<HTMLElement>('[data-recruit-image]');
+        const accent = el.querySelector<HTMLElement>('[data-recruit-accent]');
+        const subEn = el.querySelector<HTMLElement>('[data-recruit-sub-en]');
+        const heading = el.querySelector<HTMLElement>('[data-recruit-heading]');
+        const desc = el.querySelector<HTMLElement>('[data-recruit-desc]');
+        const button = el.querySelector<HTMLElement>('[data-recruit-button]');
+
+        // Initial hidden state
+        if (accent) gsap.set(accent, { scaleX: 0, transformOrigin: 'left center', opacity: 1 });
+        const fadeUpTargets = [subEn, heading, desc, button].filter(Boolean) as HTMLElement[];
+        gsap.set(fadeUpTargets, { y: 20, opacity: 0 });
+
+        const observer = new IntersectionObserver(
+          ([entry]) => {
+            if (!entry.isIntersecting) return;
+            observer.disconnect();
+
+            const tl = gsap.timeline();
+            const isDesktop = window.matchMedia('(min-width: 921px)').matches;
+
+            if (isDesktop) {
+              // Desktop: image left clipPath + text right stagger
+              if (image) {
+                gsap.set(image, { clipPath: 'inset(0 100% 0 0)', scale: 1.05, opacity: 1 });
+                tl.to(
+                  image,
+                  {
+                    clipPath: 'inset(0 0% 0 0)',
+                    scale: 1,
+                    duration: 0.9,
+                    ease: 'power3.out',
+                    onComplete: () => { image.style.removeProperty('clip-path'); },
+                  },
+                  0,
+                );
+              }
+              if (accent) tl.to(accent, { scaleX: 1, duration: 0.5, ease: 'power2.out' }, 0.2);
+              if (subEn)
+                tl.to(subEn, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.3);
+              if (heading)
+                tl.to(heading, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.4);
+              if (desc)
+                tl.to(desc, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.55);
+              if (button)
+                tl.to(button, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.7);
+            } else {
+              // Mobile: image top clipPath → text bottom stagger
+              if (image) {
+                gsap.set(image, { clipPath: 'inset(0 0 100% 0)', scale: 1.05, opacity: 1 });
+                tl.to(
+                  image,
+                  {
+                    clipPath: 'inset(0 0 0% 0)',
+                    scale: 1,
+                    duration: 0.9,
+                    ease: 'power3.out',
+                    onComplete: () => { image.style.removeProperty('clip-path'); },
+                  },
+                  0,
+                );
+              }
+              if (accent) tl.to(accent, { scaleX: 1, duration: 0.5, ease: 'power2.out' }, 0.35);
+              if (subEn)
+                tl.to(subEn, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.45);
+              if (heading)
+                tl.to(heading, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.55);
+              if (desc)
+                tl.to(desc, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.65);
+              if (button)
+                tl.to(button, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.8);
+            }
+          },
+          { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+        );
+
+        observer.observe(el);
+        return () => observer.disconnect();
+      });
+
+      mm.add('(prefers-reduced-motion: reduce)', () => {
+        const targets = el.querySelectorAll<HTMLElement>(
+          '[data-recruit-image], [data-recruit-accent], [data-recruit-sub-en], [data-recruit-heading], [data-recruit-desc], [data-recruit-button]',
+        );
+        targets.forEach((target) => {
+          target.style.opacity = '1';
+          target.style.transform = 'none';
+          target.style.removeProperty('clip-path');
+        });
+      });
+
+      cleanup = () => mm.revert();
+    })();
+
+    return () => cleanup?.();
+  }, []);
+
+  return (
+    <section ref={sectionRef} className={styles.recruitSection}>
+      <div className={styles.recruitContainer}>
+        <div className={styles.recruitImageWrap} data-recruit-image>
+          <Image
+            src="/photos/group-photo-cardboard-craft.webp"
+            alt="スタッフの活動風景"
+            width={560}
+            height={420}
+            className={styles.recruitImage}
+            sizes="(max-width: 920px) 100vw, 50vw"
+          />
+        </div>
+        <div className={styles.recruitText}>
+          <div className={styles.recruitAccent} data-recruit-accent />
+          <p className={styles.recruitSubEn} data-recruit-sub-en>
+            Join us
+          </p>
+          <h2 className={styles.recruitHeading} data-recruit-heading>
+            私たちと一緒に
+            <br />
+            働きませんか？
+          </h2>
+          <p className={styles.sectionDescription} data-recruit-desc>
+            PLDLでは、こどもたちの学びの場を一緒に創るスタッフを募集しています。
+            教育に興味がある方、こどもたちと関わることが好きな方、
+            私たちと一緒にワクワクする学びの場をデザインしませんか？
+          </p>
+          <div data-recruit-button>
+            <ButtonLink href="/contact">VIEW MORE</ButtonLink>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/_components/RecruitSectionReveal/index.tsx
+++ b/app/_components/RecruitSectionReveal/index.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import gsap from 'gsap';
+
+type Props = {
+  children: React.ReactNode;
+  direction: 'left' | 'right';
+};
+
+export default function RecruitSectionReveal({ children, direction }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference)', () => {
+      const image = el.querySelector<HTMLElement>('[data-recruit-image]');
+      const accent = el.querySelector<HTMLElement>('[data-recruit-accent]');
+      const sub = el.querySelector<HTMLElement>('[data-recruit-sub]');
+      const heading = el.querySelector<HTMLElement>('[data-recruit-heading]');
+      const bodies = el.querySelectorAll<HTMLElement>('[data-recruit-body]');
+
+      // Initial hidden state
+      if (accent) gsap.set(accent, { scaleX: 0, transformOrigin: 'left center', opacity: 1 });
+      const fadeTargets = [sub, heading].filter(Boolean) as HTMLElement[];
+      gsap.set(fadeTargets, { y: 20, opacity: 0 });
+      if (bodies.length > 0) gsap.set(bodies, { y: 15, opacity: 0 });
+
+      const isDesktop = window.matchMedia('(min-width: 921px)').matches;
+
+      if (image) {
+        const clipFrom = isDesktop
+          ? direction === 'right'
+            ? 'inset(0 100% 0 0)'
+            : 'inset(0 0 0 100%)'
+          : 'inset(0 0 100% 0)';
+        gsap.set(image, { clipPath: clipFrom, scale: 1.05, opacity: 1 });
+      }
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+
+          const tl = gsap.timeline();
+
+          // Image clipPath reveal
+          if (image) {
+            tl.to(
+              image,
+              {
+                clipPath: isDesktop ? 'inset(0 0% 0 0%)' : 'inset(0 0 0% 0)',
+                scale: 1,
+                duration: 0.9,
+                ease: 'power3.out',
+                onComplete: () => {
+                  image.style.removeProperty('clip-path');
+                },
+              },
+              0,
+            );
+          }
+
+          if (isDesktop) {
+            if (accent) tl.to(accent, { scaleX: 1, duration: 0.5, ease: 'power2.out' }, 0.15);
+            if (sub) tl.to(sub, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.25);
+            if (heading)
+              tl.to(heading, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0.35);
+            if (bodies.length > 0) {
+              tl.to(
+                bodies,
+                { y: 0, opacity: 1, duration: 0.45, ease: 'power2.out', stagger: 0.08 },
+                0.55,
+              );
+            }
+          } else {
+            if (accent) tl.to(accent, { scaleX: 1, duration: 0.5, ease: 'power2.out' }, 0.3);
+            if (sub) tl.to(sub, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.4);
+            if (heading)
+              tl.to(heading, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0.5);
+            if (bodies.length > 0) {
+              tl.to(
+                bodies,
+                { y: 0, opacity: 1, duration: 0.45, ease: 'power2.out', stagger: 0.08 },
+                0.6,
+              );
+            }
+          }
+        },
+        { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+      );
+
+      observer.observe(el);
+
+      return () => {
+        observer.disconnect();
+      };
+    });
+
+    mm.add('(prefers-reduced-motion: reduce)', () => {
+      const targets = el.querySelectorAll<HTMLElement>(
+        '[data-recruit-image], [data-recruit-accent], [data-recruit-sub], [data-recruit-heading], [data-recruit-body]',
+      );
+      targets.forEach((target) => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+        target.style.removeProperty('clip-path');
+      });
+    });
+
+    return () => mm.revert();
+  }, [direction]);
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/app/_components/ReportsList/index.tsx
+++ b/app/_components/ReportsList/index.tsx
@@ -13,7 +13,7 @@ export default function ReportsList({ reports }: Props) {
     return <p>活動レポートがありません。</p>;
   }
   return (
-    <ul>
+    <ul data-reports-list>
       {reports.map((report) => (
         <ReportsListItem key={report.id} report={report} />
       ))}

--- a/app/_components/ReportsReveal/index.tsx
+++ b/app/_components/ReportsReveal/index.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import gsap from 'gsap';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function ReportsReveal({ children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference)', () => {
+      const title = el.querySelector<HTMLElement>('[data-reports-title]');
+      const filter = el.querySelector<HTMLElement>('[data-reports-filter]');
+      const list = el.querySelector<HTMLElement>('[data-reports-list]');
+      const items = list ? list.querySelectorAll<HTMLElement>(':scope > li') : [];
+      const pagination = el.querySelector<HTMLElement>('[data-reports-pagination]');
+
+      // Initial state
+      if (title) gsap.set(title, { y: 30, opacity: 0 });
+      if (filter) gsap.set(filter, { y: 20, opacity: 0 });
+      if (items.length > 0) gsap.set(items, { y: 30, opacity: 0 });
+      if (pagination) gsap.set(pagination, { y: 15, opacity: 0 });
+
+      // IntersectionObserver — fire once
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+
+          const tl = gsap.timeline();
+          const stagger = items.length <= 6 ? 0.1 : 0.08;
+
+          if (title) {
+            tl.to(title, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0);
+          }
+          if (filter) {
+            tl.to(filter, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.15);
+          }
+          if (items.length > 0) {
+            tl.to(
+              items,
+              { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out', stagger },
+              0.3,
+            );
+          }
+          if (pagination) {
+            const paginationStart = 0.3 + items.length * stagger + 0.15;
+            tl.to(
+              pagination,
+              { y: 0, opacity: 1, duration: 0.4, ease: 'power2.out' },
+              paginationStart,
+            );
+          }
+        },
+        { threshold: 0.1, rootMargin: '0px 0px -40px 0px' },
+      );
+
+      observer.observe(el);
+
+      return () => {
+        observer.disconnect();
+      };
+    });
+
+    mm.add('(prefers-reduced-motion: reduce)', () => {
+      const targets = el.querySelectorAll<HTMLElement>(
+        '[data-reports-title], [data-reports-filter], [data-reports-list] > li, [data-reports-pagination]',
+      );
+      targets.forEach((target) => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+      });
+    });
+
+    return () => mm.revert();
+  }, []);
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/app/_components/SectionReveal/index.tsx
+++ b/app/_components/SectionReveal/index.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import gsap from 'gsap';
+
+type Props = {
+  children: React.ReactNode;
+  direction: 'left' | 'right';
+};
+
+export default function SectionReveal({ children, direction }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference)', () => {
+      const image = el.querySelector<HTMLElement>('[data-section-image]');
+      const headingEn = el.querySelector<HTMLElement>('[data-section-heading-en]');
+      const headingJa = el.querySelector<HTMLElement>('[data-section-heading-ja]');
+      const description = el.querySelector<HTMLElement>('[data-section-description]');
+      const listItems = el.querySelectorAll<HTMLElement>('[data-section-list-item]');
+
+      // Initial state
+      const textTargets = [headingEn, headingJa, description].filter(Boolean) as HTMLElement[];
+      gsap.set(textTargets, { y: 30, opacity: 0 });
+      if (listItems.length > 0) {
+        gsap.set(listItems, { y: 20, opacity: 0 });
+      }
+
+      if (image) {
+        const clipFrom =
+          direction === 'right' ? 'inset(0 100% 0 0)' : 'inset(0 0 0 100%)';
+        gsap.set(image, { clipPath: clipFrom, scale: 1.05, opacity: 1 });
+      }
+
+      // IntersectionObserver — fire once
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+
+          const tl = gsap.timeline();
+
+          // Image mask reveal
+          if (image) {
+            tl.to(
+              image,
+              {
+                clipPath: 'inset(0 0% 0 0%)',
+                scale: 1,
+                duration: 0.9,
+                ease: 'power3.out',
+                onComplete: () => {
+                  image.style.removeProperty('clip-path');
+                },
+              },
+              0,
+            );
+          }
+
+          // Text stagger
+          if (headingEn) {
+            tl.to(headingEn, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0.2);
+          }
+          if (headingJa) {
+            tl.to(headingJa, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0.35);
+          }
+          if (description) {
+            tl.to(description, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0.5);
+          }
+          if (listItems.length > 0) {
+            tl.to(
+              listItems,
+              { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out', stagger: 0.1 },
+              0.65,
+            );
+          }
+        },
+        { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+      );
+
+      observer.observe(el);
+
+      // Cleanup for matchMedia revert
+      return () => {
+        observer.disconnect();
+      };
+    });
+
+    mm.add('(prefers-reduced-motion: reduce)', () => {
+      const targets = el.querySelectorAll<HTMLElement>(
+        '[data-section-image], [data-section-heading-en], [data-section-heading-ja], [data-section-description], [data-section-list-item]',
+      );
+      targets.forEach((target) => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+        target.style.removeProperty('clip-path');
+      });
+    });
+
+    return () => mm.revert();
+  }, [direction]);
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/app/_components/Sheet/index.tsx
+++ b/app/_components/Sheet/index.tsx
@@ -4,9 +4,9 @@ type Props = {
   children: React.ReactNode;
   className?: string;
   id?: string;
-};
+} & React.ComponentPropsWithoutRef<'div'>;
 
-export default function Sheet({ children, className, id }: Props) {
+export default function Sheet({ children, className, id, ...rest }: Props) {
   const containerClass = className ? `${styles.container} ${className}` : styles.container;
-  return <div id={id} className={containerClass}>{children}</div>;
+  return <div id={id} className={containerClass} {...rest}>{children}</div>;
 }

--- a/app/_components/StepUpReveal/index.tsx
+++ b/app/_components/StepUpReveal/index.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import gsap from 'gsap';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function StepUpReveal({ children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference)', () => {
+      const accent = el.querySelector<HTMLElement>('[data-stepup-accent]');
+      const sub = el.querySelector<HTMLElement>('[data-stepup-sub]');
+      const heading = el.querySelector<HTMLElement>('[data-stepup-heading]');
+      const desc = el.querySelector<HTMLElement>('[data-stepup-desc]');
+      const cards = el.querySelectorAll<HTMLElement>('[data-stepup-card]');
+      const connectors = el.querySelectorAll<HTMLElement>('[data-stepup-connector]');
+      const note = el.querySelector<HTMLElement>('[data-stepup-note]');
+
+      // Initial hidden state
+      if (accent) gsap.set(accent, { scaleX: 0, transformOrigin: 'center center', opacity: 1 });
+      const headerTargets = [sub, heading, desc].filter(Boolean) as HTMLElement[];
+      gsap.set(headerTargets, { y: 20, opacity: 0 });
+      if (cards.length > 0) gsap.set(cards, { y: 30, opacity: 0 });
+      if (connectors.length > 0) gsap.set(connectors, { opacity: 0 });
+      if (note) gsap.set(note, { y: 15, opacity: 0 });
+
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+
+          const tl = gsap.timeline();
+
+          // Phase 1: Header
+          if (accent) tl.to(accent, { scaleX: 1, duration: 0.5, ease: 'power2.out' }, 0);
+          if (sub) tl.to(sub, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.1);
+          if (heading)
+            tl.to(heading, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.2);
+          if (desc) tl.to(desc, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.35);
+
+          // Phase 2: Card → Connector → Card → Connector → Card
+          if (cards.length > 0) {
+            tl.to(cards[0], { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.55);
+          }
+          if (connectors.length > 0) {
+            tl.to(connectors[0], { opacity: 1, duration: 0.3, ease: 'power2.out' }, 0.7);
+          }
+          if (cards.length > 1) {
+            tl.to(cards[1], { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.85);
+          }
+          if (connectors.length > 1) {
+            tl.to(connectors[1], { opacity: 1, duration: 0.3, ease: 'power2.out' }, 1.0);
+          }
+          if (cards.length > 2) {
+            tl.to(cards[2], { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 1.15);
+          }
+
+          // Phase 3: Note
+          if (note) tl.to(note, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 1.35);
+        },
+        { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+      );
+
+      observer.observe(el);
+
+      return () => {
+        observer.disconnect();
+      };
+    });
+
+    mm.add('(prefers-reduced-motion: reduce)', () => {
+      const targets = el.querySelectorAll<HTMLElement>(
+        '[data-stepup-accent], [data-stepup-sub], [data-stepup-heading], [data-stepup-desc], [data-stepup-card], [data-stepup-connector], [data-stepup-note]',
+      );
+      targets.forEach((target) => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+      });
+    });
+
+    return () => mm.revert();
+  }, []);
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/app/_components/SupportIntro/index.tsx
+++ b/app/_components/SupportIntro/index.tsx
@@ -1,0 +1,91 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import styles from '../../support/page.module.css';
+
+export default function SupportIntro() {
+  const sectionRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+
+    let cleanup: (() => void) | undefined;
+
+    (async () => {
+      const { default: gsap } = await import('gsap');
+      const mm = gsap.matchMedia();
+
+      mm.add('(prefers-reduced-motion: no-preference)', () => {
+        const lead = el.querySelector<HTMLElement>('[data-support-lead]');
+        const number = el.querySelector<HTMLElement>('[data-support-number]');
+        const text = el.querySelector<HTMLElement>('[data-support-text]');
+
+        if (lead) gsap.set(lead, { y: 20, opacity: 0 });
+        if (number) gsap.set(number, { scale: 0.5, opacity: 0 });
+        if (text) gsap.set(text, { y: 15, opacity: 0 });
+
+        const observer = new IntersectionObserver(
+          ([entry]) => {
+            if (!entry.isIntersecting) return;
+            observer.disconnect();
+
+            const tl = gsap.timeline();
+
+            if (lead) {
+              tl.to(lead, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0);
+            }
+            if (number) {
+              tl.to(
+                number,
+                { scale: 1, opacity: 1, duration: 0.6, ease: 'back.out(1.7)' },
+                0.25,
+              );
+            }
+            if (text) {
+              tl.to(text, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.4);
+            }
+          },
+          { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+        );
+
+        observer.observe(el);
+        return () => observer.disconnect();
+      });
+
+      mm.add('(prefers-reduced-motion: reduce)', () => {
+        const targets = el.querySelectorAll<HTMLElement>(
+          '[data-support-lead], [data-support-number], [data-support-text]',
+        );
+        targets.forEach((target) => {
+          target.style.opacity = '1';
+          target.style.transform = 'none';
+        });
+      });
+
+      cleanup = () => mm.revert();
+    })();
+
+    return () => cleanup?.();
+  }, []);
+
+  return (
+    <section ref={sectionRef} className={styles.intro}>
+      <div className={styles.introContainer}>
+        <p className={styles.introLead} data-support-lead>
+          PLDLの活動は、多くの方々のご支援によって支えられています。
+          <br />
+          あなたの力を、こどもたちの未来に届けてください。
+        </p>
+        <h2 className={styles.introHeading}>
+          <span className={styles.introNumber} data-support-number>
+            4
+          </span>
+          <span className={styles.introText} data-support-text>
+            つのサポート
+          </span>
+        </h2>
+      </div>
+    </section>
+  );
+}

--- a/app/_components/SupportMethodCard/index.tsx
+++ b/app/_components/SupportMethodCard/index.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import Image from 'next/image';
+import ButtonLink from '@/app/_components/ButtonLink';
+import styles from '../../support/page.module.css';
+
+type SupportMethod = {
+  number: string;
+  title: string;
+  description: string;
+  image: string;
+  imageAlt: string;
+  color: 'primary' | 'secondary' | 'tertiary' | 'accent';
+  slug: string;
+  ctaType: 'single' | 'dual';
+};
+
+type Props = {
+  method: SupportMethod;
+  index: number;
+};
+
+export default function SupportMethodCard({ method, index }: Props) {
+  const cardRef = useRef<HTMLDivElement>(null);
+  const isReverse = index % 2 !== 0;
+
+  useEffect(() => {
+    const el = cardRef.current;
+    if (!el) return;
+
+    let cleanup: (() => void) | undefined;
+
+    (async () => {
+      const { default: gsap } = await import('gsap');
+      const mm = gsap.matchMedia();
+
+      mm.add('(prefers-reduced-motion: no-preference)', () => {
+        const image = el.querySelector<HTMLElement>('[data-card-image]');
+        const number = el.querySelector<HTMLElement>('[data-card-number]');
+        const title = el.querySelector<HTMLElement>('[data-card-title]');
+        const desc = el.querySelector<HTMLElement>('[data-card-desc]');
+        const cta = el.querySelector<HTMLElement>('[data-card-cta]');
+
+        const fadeUpTargets = [number, title, desc, cta].filter(Boolean) as HTMLElement[];
+        gsap.set(fadeUpTargets, { y: 20, opacity: 0 });
+
+        const observer = new IntersectionObserver(
+          ([entry]) => {
+            if (!entry.isIntersecting) return;
+            observer.disconnect();
+
+            const tl = gsap.timeline();
+            const isMobile = window.matchMedia('(max-width: 640px)').matches;
+
+            if (isMobile) {
+              // Mobile: image reveals from top
+              if (image) {
+                gsap.set(image, { clipPath: 'inset(0 0 100% 0)', scale: 1.05, opacity: 1 });
+                tl.to(
+                  image,
+                  {
+                    clipPath: 'inset(0 0 0% 0)',
+                    scale: 1,
+                    duration: 0.9,
+                    ease: 'power3.out',
+                    onComplete: () => {
+                      image.style.removeProperty('clip-path');
+                    },
+                  },
+                  0,
+                );
+              }
+              if (number)
+                tl.to(number, { y: 0, opacity: 1, duration: 0.4, ease: 'power2.out' }, 0.3);
+              if (title)
+                tl.to(title, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.45);
+              if (desc)
+                tl.to(desc, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.55);
+              if (cta)
+                tl.to(cta, { y: 0, opacity: 1, duration: 0.4, ease: 'power2.out' }, 0.7);
+            } else {
+              // Desktop: image reveals from left (normal) or right (reverse)
+              if (image) {
+                const clipFrom = isReverse
+                  ? 'inset(0 0 0 100%)'
+                  : 'inset(0 100% 0 0)';
+                gsap.set(image, { clipPath: clipFrom, scale: 1.05, opacity: 1 });
+                tl.to(
+                  image,
+                  {
+                    clipPath: 'inset(0 0% 0 0%)',
+                    scale: 1,
+                    duration: 0.9,
+                    ease: 'power3.out',
+                    onComplete: () => {
+                      image.style.removeProperty('clip-path');
+                    },
+                  },
+                  0,
+                );
+              }
+              if (number)
+                tl.to(number, { y: 0, opacity: 1, duration: 0.4, ease: 'power2.out' }, 0.15);
+              if (title)
+                tl.to(title, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.3);
+              if (desc)
+                tl.to(desc, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, 0.45);
+              if (cta)
+                tl.to(cta, { y: 0, opacity: 1, duration: 0.4, ease: 'power2.out' }, 0.6);
+            }
+          },
+          { threshold: 0.15, rootMargin: '0px 0px -60px 0px' },
+        );
+
+        observer.observe(el);
+        return () => observer.disconnect();
+      });
+
+      mm.add('(prefers-reduced-motion: reduce)', () => {
+        const targets = el.querySelectorAll<HTMLElement>(
+          '[data-card-image], [data-card-number], [data-card-title], [data-card-desc], [data-card-cta]',
+        );
+        targets.forEach((target) => {
+          target.style.opacity = '1';
+          target.style.transform = 'none';
+          target.style.removeProperty('clip-path');
+        });
+      });
+
+      cleanup = () => mm.revert();
+    })();
+
+    return () => cleanup?.();
+  }, [isReverse]);
+
+  return (
+    <div
+      ref={cardRef}
+      className={`${styles.card} ${styles[method.color]} ${isReverse ? styles.reverse : ''}`}
+    >
+      <div className={styles.cardImageWrapper} data-card-image>
+        <Image
+          src={method.image}
+          alt={method.imageAlt}
+          fill
+          sizes="(max-width: 640px) 100vw, 50vw"
+          quality={75}
+          className={styles.cardImage}
+        />
+      </div>
+      <div className={styles.cardContent}>
+        <span className={styles.cardNumber} data-card-number>
+          {method.number}
+        </span>
+        <h3 className={styles.cardTitle} data-card-title>
+          {method.title}
+        </h3>
+        <p className={styles.cardDescription} data-card-desc>
+          {method.description}
+        </p>
+        <div className={styles.cardCta} data-card-cta>
+          {method.ctaType === 'single' ? (
+            <ButtonLink href={`/support/${method.slug}`} variant="outline">
+              ボランティアに参加する
+            </ButtonLink>
+          ) : (
+            <>
+              <ButtonLink href={`/support/${method.slug}`} variant="outline">
+                個人の方はこちら
+              </ButtonLink>
+              <ButtonLink href={`/support/${method.slug}`} variant="outline">
+                法人・団体の方はこちら
+              </ButtonLink>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/_components/TopReportsReveal/index.tsx
+++ b/app/_components/TopReportsReveal/index.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { useRef, useEffect } from 'react';
+import gsap from 'gsap';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+export default function TopReportsReveal({ children }: Props) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const mm = gsap.matchMedia();
+
+    mm.add('(prefers-reduced-motion: no-preference)', () => {
+      const title = el.querySelector<HTMLElement>('[data-tr-title]');
+      const sheet = el.querySelector<HTMLElement>('[data-tr-sheet]');
+      const items = el.querySelectorAll<HTMLElement>('[data-reports-list] > li');
+      const link = el.querySelector<HTMLElement>('[data-tr-link]');
+
+      // Initial state
+      if (title) gsap.set(title, { y: 30, opacity: 0 });
+      if (sheet) gsap.set(sheet, { y: 30, opacity: 0 });
+      if (items.length > 0) gsap.set(items, { y: 30, opacity: 0 });
+      if (link) gsap.set(link, { y: 15, opacity: 0 });
+
+      // IntersectionObserver — fire once
+      const observer = new IntersectionObserver(
+        ([entry]) => {
+          if (!entry.isIntersecting) return;
+          observer.disconnect();
+
+          const tl = gsap.timeline();
+
+          if (title) {
+            tl.to(title, { y: 0, opacity: 1, duration: 0.6, ease: 'power2.out' }, 0);
+          }
+          if (sheet) {
+            tl.to(sheet, { y: 0, opacity: 1, duration: 0.7, ease: 'power2.out' }, 0.15);
+          }
+          if (items.length > 0) {
+            tl.to(
+              items,
+              { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out', stagger: 0.1 },
+              0.35,
+            );
+          }
+          if (link) {
+            const linkDelay = 0.35 + items.length * 0.1 + 0.15;
+            tl.to(link, { y: 0, opacity: 1, duration: 0.5, ease: 'power2.out' }, linkDelay);
+          }
+        },
+        { threshold: 0.1, rootMargin: '0px 0px -40px 0px' },
+      );
+
+      observer.observe(el);
+
+      return () => {
+        observer.disconnect();
+      };
+    });
+
+    mm.add('(prefers-reduced-motion: reduce)', () => {
+      const targets = el.querySelectorAll<HTMLElement>(
+        '[data-tr-title], [data-tr-sheet], [data-reports-list] > li, [data-tr-link]',
+      );
+      targets.forEach((target) => {
+        target.style.opacity = '1';
+        target.style.transform = 'none';
+      });
+    });
+
+    return () => mm.revert();
+  }, []);
+
+  return <div ref={ref}>{children}</div>;
+}

--- a/app/_components/VisionSection/index.module.css
+++ b/app/_components/VisionSection/index.module.css
@@ -46,7 +46,7 @@
 .section {
   position: relative;
   z-index: 3;
-  padding: 100px 0;
+  padding: 130px 0;
   background: var(--color-primary);
   overflow: clip;
 }

--- a/app/_components/VisionSection/index.tsx
+++ b/app/_components/VisionSection/index.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import SectionReveal from '../SectionReveal';
 import styles from './index.module.css';
 
 export default function VisionSection() {
@@ -13,19 +14,23 @@ export default function VisionSection() {
         </svg>
       </div>
       <section className={styles.section}>
-        <div className={styles.container}>
-          <div className={styles.horizontal}>
-            <div className={styles.textArea} data-parallax="text">
-              <h2 className={styles.headingEn} data-parallax="heading">Vision</h2>
-              <p className={styles.headingJa}>ビジョン</p>
-              <p className={styles.description}>
-                すべてのこどもたちが本来もっている素晴らしい力<br />
-                それぞれのこどもが持っている個性を活かし、伸ばし<br />
-                こどもたちの未来がより良いものになっていく<br />
-                社会の実現を目指します
-              </p>
-            </div>
-            <div data-parallax="image">
+        <SectionReveal direction="right">
+          <div className={styles.container}>
+            <div className={styles.horizontal}>
+              <div className={styles.textArea}>
+                <h2 className={styles.headingEn} data-section-heading-en>
+                  Vision
+                </h2>
+                <p className={styles.headingJa} data-section-heading-ja>
+                  ビジョン
+                </p>
+                <p className={styles.description} data-section-description>
+                  すべてのこどもたちが本来もっている素晴らしい力<br />
+                  それぞれのこどもが持っている個性を活かし、伸ばし<br />
+                  こどもたちの未来がより良いものになっていく<br />
+                  社会の実現を目指します
+                </p>
+              </div>
               <Image
                 src="/photos/children-desk-writing-group.webp"
                 alt="遊びを通じて未来をつくるビジョン"
@@ -33,10 +38,11 @@ export default function VisionSection() {
                 height={960}
                 className={styles.image}
                 sizes="(max-width: 640px) 100vw, 420px"
+                data-section-image
               />
             </div>
           </div>
-        </div>
+        </SectionReveal>
       </section>
     </>
   );

--- a/app/_components/VisionSection/index.tsx
+++ b/app/_components/VisionSection/index.tsx
@@ -15,8 +15,8 @@ export default function VisionSection() {
       <section className={styles.section}>
         <div className={styles.container}>
           <div className={styles.horizontal}>
-            <div className={styles.textArea}>
-              <h2 className={styles.headingEn}>Vision</h2>
+            <div className={styles.textArea} data-parallax="text">
+              <h2 className={styles.headingEn} data-parallax="heading">Vision</h2>
               <p className={styles.headingJa}>ビジョン</p>
               <p className={styles.description}>
                 すべてのこどもたちが本来もっている素晴らしい力<br />
@@ -25,14 +25,16 @@ export default function VisionSection() {
                 社会の実現を目指します
               </p>
             </div>
-            <Image
-              src="/photos/children-desk-writing-group.webp"
-              alt="遊びを通じて未来をつくるビジョン"
-              width={960}
-              height={960}
-              className={styles.image}
-              sizes="(max-width: 640px) 100vw, 420px"
-            />
+            <div data-parallax="image">
+              <Image
+                src="/photos/children-desk-writing-group.webp"
+                alt="遊びを通じて未来をつくるビジョン"
+                width={960}
+                height={960}
+                className={styles.image}
+                sizes="(max-width: 640px) 100vw, 420px"
+              />
+            </div>
           </div>
         </div>
       </section>

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -6,9 +6,12 @@ import { getMembersList, type Member } from '@/app/_libs/microcms';
 import Hero from '@/app/_components/Hero';
 import VisionSection from '@/app/_components/VisionSection';
 import MissionSection from '@/app/_components/MissionSection';
-import ButtonLink from '@/app/_components/ButtonLink';
 import ScrollReveal from '@/app/_components/ScrollReveal';
 import MemberCarousel from '@/app/_components/MemberCarousel';
+import MessageSection from '@/app/_components/MessageSection';
+import IntroSection from '@/app/_components/IntroSection';
+import RecruitSection from '@/app/_components/RecruitSection';
+import PlaceSection from '@/app/_components/PlaceSection';
 import styles from './page.module.css';
 
 export const metadata: Metadata = {
@@ -42,15 +45,6 @@ const REPORT_YEARS = [
   },
 ] as const;
 
-const ORG_INFO_ITEMS = [
-  { term: '名称', description: 'NPO法人 Playful Learning Design Lab.' },
-  { term: '設立', description: '2022年10月' },
-  { term: '代表理事', description: '尾池咲季子（松島）' },
-  { term: '理事', description: '近藤隼人　浦田充起' },
-  { term: '監事', description: '新井雄一　アライ商会株式会社 代表取締役' },
-  { term: '所在地', description: '〒379-2313 群馬県みどり市笠懸町鹿3616-1' },
-] as const;
-
 export default async function Page() {
   let members: Member[] = [];
   try {
@@ -69,196 +63,24 @@ export default async function Page() {
       />
 
       {/* 紹介セクション */}
-      <section className={styles.intro}>
-        <div className={styles.introContainer}>
-          <div className={styles.introText}>
-            <h2 className={styles.introTitle}>
-              ワクワクする学びが
-              <br />
-              こどもたちの未来を創る
-            </h2>
-            <p className={styles.introDescription}>
-              「知らないことを知ることは楽しい」
-              <br />
-              学びとは本来ワクワクするものです。
-              <br />
-              私たちは「学びのワクワク」を様々なプロジェクトを
-              <br />
-              通じて、こどもたちに伝えていきます。
-            </p>
-            <p className={styles.introDescription}>
-              学ぶことの楽しさを知った子どもたちは
-              <br />
-              自分で考え、行動し、自分の未来を切り拓くことが
-              <br />
-              できると信じています。
-            </p>
-            <p className={styles.introDescription}>
-              NPO法人PLDLでは、様々なワクワクの場を
-              <br />
-              デザインしていきます。
-            </p>
-            <ButtonLink href="/activities">PLDLについて</ButtonLink>
-          </div>
-          <div className={styles.introImageWrap}>
-            <Image
-              src="/photos/boys-sawing-branch-outdoor.webp"
-              alt="活動の様子"
-              width={480}
-              height={480}
-              className={styles.introImage}
-              sizes="(max-width: 640px) 200px, (max-width: 768px) 260px, 360px"
-            />
-          </div>
-        </div>
-      </section>
+      <IntroSection />
 
       <VisionSection />
       <MissionSection />
 
       {/* メンバーセクション */}
       {members.length > 0 && (
-        <ScrollReveal>
-          <MemberCarousel members={members} />
-        </ScrollReveal>
+        <MemberCarousel members={members} />
       )}
 
       {/* 代表のメッセージセクション */}
-      <ScrollReveal delay={100}>
-        <section className={styles.messageSection}>
-          <div className={styles.messageContainer}>
-            <div className={styles.messageText}>
-              <div className={styles.messageAccent} />
-              <p className={styles.messageSubEn}>Message</p>
-              <h2 className={styles.messageHeading}>代表のメッセージ</h2>
-              <div className={styles.messageImageMobile}>
-                <Image
-                  src="/images/assets/matsushima-sakiko.webp"
-                  alt="代表理事 松島咲季子"
-                  width={280}
-                  height={280}
-                  className={styles.messageImageCircle}
-                  sizes="200px"
-                />
-              </div>
-              <div className={styles.messageBody}>
-                <p>
-                  はじめてこどもたちとワークショップをした日、こどもたちは
-                  想像をはるかに超える創造力と好奇心で私を圧倒してくれました。
-                </p>
-                <p>
-                  成長していく中で環境や一部の評価などを理由に
-                  学びからドロップアウトしてしまうこどもが多いのが現状です。
-                  しかし、私はあの日、すべてのこどもたちは平等に素晴らしい力を持っていて
-                  その力さえ引き出せれば、創造力と好奇心と、そして強い意志をもって
-                  未来を切り開いていくことができると実感しました。
-                </p>
-                <p>
-                  私たちは、学ぶことは楽しい、知らないことを知ることは面白いことというポジティブな
-                  マインドをもったこどもを一人でも増やしたいという思いでこの事業を立ち上げました。
-                </p>
-                <p>
-                  環境や経済状況に関わらず自らの力と意志で自分の未来を切り開いてくれるこどもが
-                  増えることを目指して私たちはこどもたちの「したい！」「知りたい！」を全力でサポートし続けます。
-                </p>
-              </div>
-              <div className={styles.messageSignature}>
-                <span className={styles.signatureRole}>代表理事</span>
-                <span className={styles.signatureName}>松島咲季子</span>
-              </div>
-            </div>
-            <div className={styles.messageImageWrap}>
-              <Image
-                src="/images/assets/matsushima-sakiko.webp"
-                alt="代表理事 松島咲季子"
-                width={400}
-                height={400}
-                className={styles.messageImage}
-                sizes="(max-width: 920px) 100vw, 350px"
-              />
-            </div>
-          </div>
-        </section>
-      </ScrollReveal>
+      <MessageSection />
 
       {/* スタッフ募集中セクション */}
-      <ScrollReveal delay={100}>
-        <section className={styles.recruitSection}>
-          <div className={styles.recruitContainer}>
-            <div className={styles.recruitImageWrap}>
-              <Image
-                src="/photos/group-photo-cardboard-craft.webp"
-                alt="スタッフの活動風景"
-                width={560}
-                height={420}
-                className={styles.recruitImage}
-                sizes="(max-width: 920px) 100vw, 50vw"
-              />
-            </div>
-            <div className={styles.recruitText}>
-              <div className={styles.recruitAccent} />
-              <p className={styles.recruitSubEn}>Join us</p>
-              <h2 className={styles.recruitHeading}>
-                私たちと一緒に
-                <br />
-                働きませんか？
-              </h2>
-              <p className={styles.sectionDescription}>
-                PLDLでは、こどもたちの学びの場を一緒に創るスタッフを募集しています。
-                教育に興味がある方、こどもたちと関わることが好きな方、
-                私たちと一緒にワクワクする学びの場をデザインしませんか？
-              </p>
-              <ButtonLink href="/contact">
-                VIEW MORE
-              </ButtonLink>
-            </div>
-          </div>
-        </section>
-      </ScrollReveal>
+      <RecruitSection />
 
       {/* PLDLの場所セクション */}
-      <ScrollReveal delay={100}>
-        <section className={styles.placeSection}>
-          <div className={styles.placeContainer}>
-            <div className={styles.placeText}>
-              <div className={styles.placeAccent} />
-              <p className={styles.placeSubEn}>Place</p>
-              <h2 className={styles.placeHeading}>PLDLの場所</h2>
-              <p className={styles.sectionDescription}>
-                NPO法人PLDLの基本情報をご紹介します。
-              </p>
-              <dl className={styles.orgInfo}>
-                {ORG_INFO_ITEMS.map((item) => (
-                  <div key={item.term} className={styles.orgInfoRow}>
-                    <dt className={styles.orgInfoTerm}>{item.term}</dt>
-                    <dd className={styles.orgInfoDesc}>{item.description}</dd>
-                  </div>
-                ))}
-              </dl>
-            </div>
-            <div className={styles.placeImageWrap}>
-              <Image
-                src="/photos/children-walking-outdoor-sunny.webp"
-                alt="晴れた日に歩くこどもたち"
-                width={560}
-                height={420}
-                className={styles.placeImage}
-                sizes="(max-width: 920px) 100vw, 50vw"
-              />
-            </div>
-          </div>
-          <div className={styles.mapWrap}>
-            <iframe
-              className={styles.mapIframe}
-              src="https://www.google.com/maps?q=群馬県みどり市笠懸町鹿3616-1&output=embed"
-              title="NPO法人PLDLの所在地"
-              loading="lazy"
-              referrerPolicy="no-referrer-when-downgrade"
-              allowFullScreen
-            />
-          </div>
-        </section>
-      </ScrollReveal>
+      <PlaceSection />
 
       {/* 決算・活動報告書セクション */}
       <ScrollReveal delay={100}>

--- a/app/activities/p/[current]/page.tsx
+++ b/app/activities/p/[current]/page.tsx
@@ -7,6 +7,7 @@ import ActivityCard from '@/app/_components/ActivityCard';
 import Pagination from '@/app/_components/Pagination';
 import CategoryFilter from '@/app/_components/CategoryFilter';
 import BusinessCard from '@/app/_components/BusinessCard';
+import ReportsReveal from '@/app/_components/ReportsReveal';
 import styles from './page.module.css';
 import activitiesStyles from '../../page.module.css';
 
@@ -100,15 +101,21 @@ export default async function Page(props: Props) {
       {selectedIds.length > 0 ? (
         <>
           <section id="reports" className={styles.reports}>
-            <h2 className={styles.sectionTitle}>{title}</h2>
-            <CategoryFilter categories={categories} selectedIds={selectedIds} scrollTargetId="reports" />
-            <ReportsList reports={reportsData.contents} />
-            <Pagination
-              totalCount={reportsData.totalCount}
-              current={current}
-              basePath="/activities"
-              q={`category=${selectedIds.join(',')}`}
-            />
+            <ReportsReveal>
+              <h2 className={styles.sectionTitle} data-reports-title>{title}</h2>
+              <div data-reports-filter>
+                <CategoryFilter categories={categories} selectedIds={selectedIds} scrollTargetId="reports" />
+              </div>
+              <ReportsList reports={reportsData.contents} />
+              <div data-reports-pagination>
+                <Pagination
+                  totalCount={reportsData.totalCount}
+                  current={current}
+                  basePath="/activities"
+                  q={`category=${selectedIds.join(',')}`}
+                />
+              </div>
+            </ReportsReveal>
           </section>
 
           {topCategories.length > 0 && (
@@ -143,10 +150,16 @@ export default async function Page(props: Props) {
           )}
 
           <section id="reports" className={styles.reports}>
-            <h2 className={styles.sectionTitle}>活動レポート</h2>
-            <CategoryFilter categories={categories} selectedIds={selectedIds} scrollTargetId="reports" />
-            <ReportsList reports={reportsData.contents} />
-            <Pagination totalCount={reportsData.totalCount} current={current} basePath="/activities" />
+            <ReportsReveal>
+              <h2 className={styles.sectionTitle} data-reports-title>活動レポート</h2>
+              <div data-reports-filter>
+                <CategoryFilter categories={categories} selectedIds={selectedIds} scrollTargetId="reports" />
+              </div>
+              <ReportsList reports={reportsData.contents} />
+              <div data-reports-pagination>
+                <Pagination totalCount={reportsData.totalCount} current={current} basePath="/activities" />
+              </div>
+            </ReportsReveal>
           </section>
         </>
       )}

--- a/app/activities/page.tsx
+++ b/app/activities/page.tsx
@@ -8,6 +8,7 @@ import ReportsList from '@/app/_components/ReportsList';
 import Pagination from '@/app/_components/Pagination';
 import BusinessCard from '@/app/_components/BusinessCard';
 import CategoryFilter from '@/app/_components/CategoryFilter';
+import ReportsReveal from '@/app/_components/ReportsReveal';
 import styles from './page.module.css';
 
 type Props = {
@@ -89,15 +90,21 @@ export default async function Page({ searchParams }: Props) {
       <Hero title="活動内容" sub="Activities" imageSrc="/photos/kids-craft-activity-table.webp" />
 
       <Sheet id="reports">
-        <h2 className={styles.sectionTitle}>{title}</h2>
-        <CategoryFilter categories={categories} selectedIds={selectedIds} scrollTargetId="reports" />
-        <ReportsList reports={reportsData.contents} />
-        <Pagination
-          totalCount={reportsData.totalCount}
-          current={1}
-          basePath="/activities"
-          q={selectedIds.length > 0 ? `category=${selectedIds.join(',')}` : undefined}
-        />
+        <ReportsReveal>
+          <h2 className={styles.sectionTitle} data-reports-title>{title}</h2>
+          <div data-reports-filter>
+            <CategoryFilter categories={categories} selectedIds={selectedIds} scrollTargetId="reports" />
+          </div>
+          <ReportsList reports={reportsData.contents} />
+          <div data-reports-pagination>
+            <Pagination
+              totalCount={reportsData.totalCount}
+              current={1}
+              basePath="/activities"
+              q={selectedIds.length > 0 ? `category=${selectedIds.join(',')}` : undefined}
+            />
+          </div>
+        </ReportsReveal>
       </Sheet>
 
       {topCategories.length > 0 && (

--- a/app/globals.css
+++ b/app/globals.css
@@ -179,3 +179,79 @@ img {
   -webkit-user-drag: none;
   user-select: none;
 }
+
+/* =========================================
+   GSAP FOUC Prevention
+   ========================================= */
+@media (prefers-reduced-motion: no-preference) {
+  /* SupportIntro */
+  [data-support-lead],
+  [data-support-number],
+  [data-support-text],
+  /* SupportMethodCard */
+  [data-card-image],
+  [data-card-number],
+  [data-card-title],
+  [data-card-desc],
+  [data-card-cta],
+  /* IntroSection */
+  [data-intro-title],
+  [data-intro-desc],
+  [data-intro-button],
+  [data-intro-image],
+  /* RecruitSection & RecruitSectionReveal */
+  [data-recruit-image],
+  [data-recruit-accent],
+  [data-recruit-sub-en],
+  [data-recruit-sub],
+  [data-recruit-heading],
+  [data-recruit-desc],
+  [data-recruit-body],
+  [data-recruit-button],
+  /* PlaceSection */
+  [data-place-accent],
+  [data-place-sub-en],
+  [data-place-heading],
+  [data-place-desc],
+  [data-place-info-row],
+  [data-place-image],
+  [data-place-map],
+  /* SectionReveal */
+  [data-section-image],
+  [data-section-heading-en],
+  [data-section-heading-ja],
+  [data-section-description],
+  [data-section-list-item],
+  /* ActivitiesReveal */
+  [data-activities-title],
+  [data-activities-description],
+  [data-activities-card],
+  [data-activities-cta],
+  /* ReportsReveal & TopReportsReveal */
+  [data-reports-title],
+  [data-reports-filter],
+  [data-reports-list] > li,
+  [data-reports-pagination],
+  [data-tr-title],
+  [data-tr-sheet],
+  [data-tr-link],
+  /* StepUpReveal */
+  [data-stepup-accent],
+  [data-stepup-sub],
+  [data-stepup-heading],
+  [data-stepup-desc],
+  [data-stepup-card],
+  [data-stepup-connector],
+  [data-stepup-note],
+  /* RecruitCtaReveal */
+  [data-rcta-lead],
+  [data-rcta-heading],
+  [data-rcta-button],
+  /* CtaReveal */
+  [data-cta-bg],
+  [data-cta-heading],
+  [data-cta-text],
+  [data-cta-button] {
+    opacity: 0;
+  }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -120,6 +120,7 @@ export default async function RootLayout({ children }: Props) {
           streetAddress: '笠懸町鹿3616-1',
         },
         nonprofitStatus: 'NonprofitNPOC',
+        sameAs: ['https://www.instagram.com/playful_learning_design_lab/'],
       },
       {
         '@type': 'WebSite',

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import Hero from '@/app/_components/Hero';
 import ReportsList from '@/app/_components/ReportsList';
 import VisionSection from '@/app/_components/VisionSection';
 import MissionSection from '@/app/_components/MissionSection';
+import ParallaxSection from '@/app/_components/ParallaxSection';
 import BusinessCard from '@/app/_components/BusinessCard';
 import ButtonLink from '@/app/_components/ButtonLink';
 import Sheet from '@/app/_components/Sheet';
@@ -54,26 +55,32 @@ export default async function Page() {
       />
 
       {/* Activity Reports Section */}
-      <ScrollReveal>
+      <ParallaxSection>
         <section className={styles.reports}>
           <div className={styles.reportsInner}>
             <div className={styles.reportsDecoration} aria-hidden="true" />
-            <h2 className={styles.reportsVerticalTitle}>活動レポート</h2>
-            <Sheet className={styles.reportsSheet}>
-              <ReportsList reports={reportsData.contents} />
-              <div className={styles.reportsLink}>
-                <ButtonLink href="/activities">もっと見る</ButtonLink>
-              </div>
-            </Sheet>
+            <h2 className={styles.reportsVerticalTitle} data-parallax="heading" data-parallax-speed="-120">活動レポート</h2>
+            <div data-parallax="text" data-parallax-speed="-50">
+              <Sheet className={styles.reportsSheet}>
+                <ReportsList reports={reportsData.contents} />
+                <div className={styles.reportsLink}>
+                  <ButtonLink href="/activities">もっと見る</ButtonLink>
+                </div>
+              </Sheet>
+            </div>
           </div>
         </section>
-      </ScrollReveal>
+      </ParallaxSection>
 
       {/* VISION Section */}
-      <VisionSection />
+      <ParallaxSection>
+        <VisionSection />
+      </ParallaxSection>
 
       {/* MISSION Section */}
-      <MissionSection />
+      <ParallaxSection>
+        <MissionSection />
+      </ParallaxSection>
 
       {/* Activities Section */}
       {topCategories.length > 0 ? (
@@ -137,7 +144,7 @@ export default async function Page() {
                 <ExternalLink size={16} className={styles.snsCardArrow} aria-hidden />
               </Link>
               <Link
-                href="https://instagram.com/"
+                href="https://www.instagram.com/playful_learning_design_lab/"
                 target="_blank"
                 rel="noopener noreferrer"
                 className={`${styles.snsCard} ${styles.snsCardInstagram}`}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,11 +7,12 @@ import Hero from '@/app/_components/Hero';
 import ReportsList from '@/app/_components/ReportsList';
 import VisionSection from '@/app/_components/VisionSection';
 import MissionSection from '@/app/_components/MissionSection';
-import ParallaxSection from '@/app/_components/ParallaxSection';
 import BusinessCard from '@/app/_components/BusinessCard';
 import ButtonLink from '@/app/_components/ButtonLink';
 import Sheet from '@/app/_components/Sheet';
 import ScrollReveal from '@/app/_components/ScrollReveal';
+import ActivitiesReveal from '@/app/_components/ActivitiesReveal';
+import TopReportsReveal from '@/app/_components/TopReportsReveal';
 import styles from './page.module.css';
 
 export default async function Page() {
@@ -55,57 +56,54 @@ export default async function Page() {
       />
 
       {/* Activity Reports Section */}
-      <ParallaxSection>
+      <TopReportsReveal>
         <section className={styles.reports}>
           <div className={styles.reportsInner}>
             <div className={styles.reportsDecoration} aria-hidden="true" />
-            <h2 className={styles.reportsVerticalTitle} data-parallax="heading" data-parallax-speed="-120">活動レポート</h2>
-            <div data-parallax="text" data-parallax-speed="-50">
-              <Sheet className={styles.reportsSheet}>
-                <ReportsList reports={reportsData.contents} />
-                <div className={styles.reportsLink}>
-                  <ButtonLink href="/activities">もっと見る</ButtonLink>
-                </div>
-              </Sheet>
-            </div>
+            <h2 className={styles.reportsVerticalTitle} data-tr-title>活動レポート</h2>
+            <Sheet className={styles.reportsSheet} data-tr-sheet>
+              <ReportsList reports={reportsData.contents} />
+              <div className={styles.reportsLink} data-tr-link>
+                <ButtonLink href="/activities">もっと見る</ButtonLink>
+              </div>
+            </Sheet>
           </div>
         </section>
-      </ParallaxSection>
+      </TopReportsReveal>
 
       {/* VISION Section */}
-      <ParallaxSection>
-        <VisionSection />
-      </ParallaxSection>
+      <VisionSection />
 
       {/* MISSION Section */}
-      <ParallaxSection>
-        <MissionSection />
-      </ParallaxSection>
+      <MissionSection />
 
       {/* Activities Section */}
       {topCategories.length > 0 ? (
-        <ScrollReveal>
+        <ActivitiesReveal>
           <section className={styles.activities}>
             <div className={styles.activitiesContainer}>
-              <h2 className={styles.sectionTitle}>活動内容について</h2>
-              <p className={styles.activitiesDescription}>
+              <h2 className={styles.sectionTitle} data-activities-title>
+                活動内容について
+              </h2>
+              <p className={styles.activitiesDescription} data-activities-description>
                 遊びや体験を通じて、子供たちの好奇心と創造力を育む多彩なプログラムを提供しています。
               </p>
               <div className={styles.activitiesGrid}>
                 {topCategories.map((category) => (
-                  <BusinessCard
-                    key={category.id}
-                    category={category}
-                    href={`/activities?category=${category.id}`}
-                  />
+                  <div key={category.id} data-activities-card>
+                    <BusinessCard
+                      category={category}
+                      href={`/activities?category=${category.id}`}
+                    />
+                  </div>
                 ))}
               </div>
-              <div className={styles.activitiesLink}>
+              <div className={styles.activitiesLink} data-activities-cta>
                 <ButtonLink href="/activities">すべての活動を見る</ButtonLink>
               </div>
             </div>
           </section>
-        </ScrollReveal>
+        </ActivitiesReveal>
       ) : null}
 
       {/* SNS Section */}

--- a/app/recruit/page.tsx
+++ b/app/recruit/page.tsx
@@ -2,7 +2,9 @@ import { Metadata } from 'next';
 import Image from 'next/image';
 import Hero from '@/app/_components/Hero';
 import ButtonLink from '@/app/_components/ButtonLink';
-import ScrollReveal from '@/app/_components/ScrollReveal';
+import RecruitSectionReveal from '@/app/_components/RecruitSectionReveal';
+import StepUpReveal from '@/app/_components/StepUpReveal';
+import RecruitCtaReveal from '@/app/_components/RecruitCtaReveal';
 import styles from './page.module.css';
 
 export const metadata: Metadata = {
@@ -28,30 +30,30 @@ export default function Page() {
       />
 
       {/* Section 1: こどもたちの未来をより良くすること */}
-      <ScrollReveal>
+      <RecruitSectionReveal direction="right">
         <section className={styles.section}>
           <div className={styles.sectionContainer}>
             <div className={styles.sectionText}>
-              <div className={styles.accent} />
-              <p className={styles.subEn}>01 — For Children</p>
-              <h2 className={styles.sectionHeading}>
+              <div className={styles.accent} data-recruit-accent />
+              <p className={styles.subEn} data-recruit-sub>01 — For Children</p>
+              <h2 className={styles.sectionHeading} data-recruit-heading>
                 こどもたちの未来を
                 <br />
                 より良くすること
               </h2>
-              <p className={styles.sectionBody}>
+              <p className={styles.sectionBody} data-recruit-body>
                 PLDLの活動は、すべて「こどもたちのために」という想いから始まっています。
               </p>
-              <p className={styles.sectionBody}>
+              <p className={styles.sectionBody} data-recruit-body>
                 学校でも家庭でもない「第三の居場所」で、こどもたちが安心して過ごせる環境をつくること。
                 そこで出会う大人たちが、こどもたちにとって信頼できる存在であること。
               </p>
-              <p className={styles.sectionBody}>
+              <p className={styles.sectionBody} data-recruit-body>
                 わたしたちと一緒に活動するということは、こどもたちの日常に寄り添い、
                 その成長を間近で見守る「並走する仲間」になるということです。
               </p>
             </div>
-            <div className={`${styles.sectionImageWrap} ${styles.imageFramePrimary}`}>
+            <div className={`${styles.sectionImageWrap} ${styles.imageFramePrimary}`} data-recruit-image>
               <Image
                 src="/photos/children-stream-exploration.webp"
                 alt="大人と一緒に川で探検するこどもたち"
@@ -62,35 +64,35 @@ export default function Page() {
             </div>
           </div>
         </section>
-      </ScrollReveal>
+      </RecruitSectionReveal>
 
       {/* Section 2: 自分のスキルやノウハウを還元すること */}
-      <ScrollReveal>
+      <RecruitSectionReveal direction="left">
         <section className={`${styles.section} ${styles.sectionAlt}`}>
           <div className={`${styles.sectionContainer} ${styles.sectionReverse}`}>
             <div className={styles.sectionText}>
-              <div className={styles.accent} />
-              <p className={styles.subEn}>02 — Your Skills Matter</p>
-              <h2 className={styles.sectionHeading}>
+              <div className={styles.accent} data-recruit-accent />
+              <p className={styles.subEn} data-recruit-sub>02 — Your Skills Matter</p>
+              <h2 className={styles.sectionHeading} data-recruit-heading>
                 自分のスキルやノウハウを
                 <br />
                 還元すること
               </h2>
-              <p className={styles.sectionBody}>
+              <p className={styles.sectionBody} data-recruit-body>
                 PLDLでの活動には、特別な資格は必要ありません。
               </p>
-              <p className={styles.sectionBody}>
+              <p className={styles.sectionBody} data-recruit-body>
                 料理が得意な人は、こどもたちと一緒に調理体験を。
                 スポーツが好きな人は、外遊びの企画を。
                 ものづくりが好きな人は、工作やプログラミングのワークショップを。
               </p>
-              <p className={styles.sectionBody}>
+              <p className={styles.sectionBody} data-recruit-body>
                 あなたが持っている「好き」や「得意」は、
                 こどもたちにとってかけがえのない体験になります。
                 日常の中で培ってきたスキルやノウハウを、次の世代に届けてみませんか。
               </p>
             </div>
-            <div className={`${styles.sectionImageWrap} ${styles.imageFrameSecondary}`}>
+            <div className={`${styles.sectionImageWrap} ${styles.imageFrameSecondary}`} data-recruit-image>
               <Image
                 src="/photos/child-cardboard-bottle-craft.webp"
                 alt="段ボールとペットボトルで工作するこども"
@@ -101,34 +103,34 @@ export default function Page() {
             </div>
           </div>
         </section>
-      </ScrollReveal>
+      </RecruitSectionReveal>
 
       {/* Section 3: 教育における社会課題解決に寄与すること */}
-      <ScrollReveal>
+      <RecruitSectionReveal direction="right">
         <section className={styles.section}>
           <div className={styles.sectionContainer}>
             <div className={styles.sectionText}>
-              <div className={styles.accent} />
-              <p className={styles.subEn}>03 — Social Impact</p>
-              <h2 className={styles.sectionHeading}>
+              <div className={styles.accent} data-recruit-accent />
+              <p className={styles.subEn} data-recruit-sub>03 — Social Impact</p>
+              <h2 className={styles.sectionHeading} data-recruit-heading>
                 教育における社会課題解決に
                 <br />
                 寄与すること
               </h2>
-              <p className={styles.sectionBody}>
+              <p className={styles.sectionBody} data-recruit-body>
                 日本では、約7人に1人のこどもが相対的貧困の状態にあると言われています。
                 経済的な理由で学びの機会や体験活動が制限されるこどもたちがいます。
               </p>
-              <p className={styles.sectionBody}>
+              <p className={styles.sectionBody} data-recruit-body>
                 PLDLは、すべてのこどもたちに等しく学びと体験の機会を届けるために活動しています。
                 わたしたちの活動に参加することは、教育格差という社会課題に対して、
                 あなた自身が直接アクションを起こすことにつながります。
               </p>
-              <p className={styles.sectionBody}>
+              <p className={styles.sectionBody} data-recruit-body>
                 一人ひとりの参加が、社会を変える力になります。
               </p>
             </div>
-            <div className={`${styles.sectionImageWrap} ${styles.imageFrameTertiary}`}>
+            <div className={`${styles.sectionImageWrap} ${styles.imageFrameTertiary}`} data-recruit-image>
               <Image
                 src="/photos/kids-reading-together.webp"
                 alt="一緒に本を読むこどもたち"
@@ -139,24 +141,24 @@ export default function Page() {
             </div>
           </div>
         </section>
-      </ScrollReveal>
+      </RecruitSectionReveal>
 
       {/* Section 4: ステップアップ制度 */}
-      <ScrollReveal>
+      <StepUpReveal>
         <section className={`${styles.section} ${styles.sectionAlt}`}>
           <div className={styles.stepUpContainer}>
-            <div className={styles.accent} style={{ margin: '0 auto' }} />
-            <p className={styles.subEn} style={{ textAlign: 'center' }}>
+            <div className={styles.accent} style={{ margin: '0 auto' }} data-stepup-accent />
+            <p className={styles.subEn} style={{ textAlign: 'center' }} data-stepup-sub>
               Step-Up Program
             </p>
-            <h2 className={styles.stepUpHeading}>ステップアップ制度</h2>
-            <p className={styles.stepUpDescription}>
+            <h2 className={styles.stepUpHeading} data-stepup-heading>ステップアップ制度</h2>
+            <p className={styles.stepUpDescription} data-stepup-desc>
               PLDLでは、ボランティアスタッフからスタートして、
               経験を積みながらステップアップしていく仕組みがあります。
             </p>
 
             <div className={styles.stepFlow}>
-              <div className={styles.stepCard}>
+              <div className={styles.stepCard} data-stepup-card>
                 <div className={styles.stepBadge}>1</div>
                 <h3 className={styles.stepTitle}>ボランティア</h3>
                 <p className={styles.stepBody}>
@@ -165,7 +167,7 @@ export default function Page() {
                 </p>
               </div>
 
-              <div className={styles.stepConnector} aria-hidden="true">
+              <div className={styles.stepConnector} aria-hidden="true" data-stepup-connector>
                 <div className={styles.stepDots}>
                   <span className={styles.stepDot} />
                   <span className={styles.stepDot} />
@@ -173,7 +175,7 @@ export default function Page() {
                 </div>
               </div>
 
-              <div className={styles.stepCard}>
+              <div className={styles.stepCard} data-stepup-card>
                 <div className={styles.stepBadge}>2</div>
                 <h3 className={styles.stepTitle}>経験を積む</h3>
                 <p className={styles.stepBody}>
@@ -182,7 +184,7 @@ export default function Page() {
                 </p>
               </div>
 
-              <div className={styles.stepConnector} aria-hidden="true">
+              <div className={styles.stepConnector} aria-hidden="true" data-stepup-connector>
                 <div className={styles.stepDots}>
                   <span className={styles.stepDot} />
                   <span className={styles.stepDot} />
@@ -190,7 +192,7 @@ export default function Page() {
                 </div>
               </div>
 
-              <div className={styles.stepCard}>
+              <div className={styles.stepCard} data-stepup-card>
                 <div className={styles.stepBadge}>3</div>
                 <h3 className={styles.stepTitle}>スタッフへ</h3>
                 <p className={styles.stepBody}>
@@ -200,7 +202,7 @@ export default function Page() {
               </div>
             </div>
 
-            <div className={styles.stepNote}>
+            <div className={styles.stepNote} data-stepup-note>
               <p>
                 最初から大きな責任を負う必要はありません。
                 あなたのペースで、できることから始めていただければ大丈夫です。
@@ -208,32 +210,34 @@ export default function Page() {
             </div>
           </div>
         </section>
-      </ScrollReveal>
+      </StepUpReveal>
 
       {/* CTA */}
-      <div className={styles.waveTop} aria-hidden="true">
-        <svg viewBox="0 0 1440 80" preserveAspectRatio="none">
-          <path d="M0,80 C240,70 480,0 720,30 C960,60 1200,10 1440,25 L1440,80 L0,80 Z" />
-        </svg>
-      </div>
-      <section className={styles.cta}>
-        <div className={styles.ctaContainer}>
-          <p className={styles.ctaLead}>週1からでも歓迎です。</p>
-          <h2 className={styles.ctaHeading}>
-            私たちと働きませんか？
-          </h2>
-          <div className={styles.ctaButton}>
-            <ButtonLink href="/contact" variant="dark">
-              お問い合わせ
-            </ButtonLink>
-          </div>
+      <RecruitCtaReveal>
+        <div className={styles.waveTop} aria-hidden="true">
+          <svg viewBox="0 0 1440 80" preserveAspectRatio="none">
+            <path d="M0,80 C240,70 480,0 720,30 C960,60 1200,10 1440,25 L1440,80 L0,80 Z" />
+          </svg>
         </div>
-      </section>
-      <div className={styles.waveBottom} aria-hidden="true">
-        <svg viewBox="0 0 1440 80" preserveAspectRatio="none">
-          <path d="M0,0 C240,10 480,80 720,50 C960,20 1200,70 1440,55 L1440,0 L0,0 Z" />
-        </svg>
-      </div>
+        <section className={styles.cta}>
+          <div className={styles.ctaContainer}>
+            <p className={styles.ctaLead} data-rcta-lead>週1からでも歓迎です。</p>
+            <h2 className={styles.ctaHeading} data-rcta-heading>
+              私たちと働きませんか？
+            </h2>
+            <div className={styles.ctaButton} data-rcta-button>
+              <ButtonLink href="/contact" variant="dark">
+                お問い合わせ
+              </ButtonLink>
+            </div>
+          </div>
+        </section>
+        <div className={styles.waveBottom} aria-hidden="true">
+          <svg viewBox="0 0 1440 80" preserveAspectRatio="none">
+            <path d="M0,0 C240,10 480,80 720,50 C960,20 1200,70 1440,55 L1440,0 L0,0 Z" />
+          </svg>
+        </div>
+      </RecruitCtaReveal>
     </>
   );
 }

--- a/app/support/page.tsx
+++ b/app/support/page.tsx
@@ -1,8 +1,7 @@
 import { Metadata } from 'next';
-import Image from 'next/image';
 import Hero from '@/app/_components/Hero';
-import ButtonLink from '@/app/_components/ButtonLink';
-import ScrollReveal from '@/app/_components/ScrollReveal';
+import SupportIntro from '@/app/_components/SupportIntro';
+import SupportMethodCard from '@/app/_components/SupportMethodCard';
 import styles from './page.module.css';
 
 export const metadata: Metadata = {
@@ -74,64 +73,12 @@ export default function Page() {
         compact
       />
 
-      <section className={styles.intro}>
-        <div className={styles.introContainer}>
-          <ScrollReveal>
-            <p className={styles.introLead}>
-              PLDLの活動は、多くの方々のご支援によって支えられています。
-              <br />
-              あなたの力を、こどもたちの未来に届けてください。
-            </p>
-          </ScrollReveal>
-          <ScrollReveal delay={200}>
-            <h2 className={styles.introHeading}>
-              <span className={styles.introNumber}>4</span>
-              <span className={styles.introText}>つのサポート</span>
-            </h2>
-          </ScrollReveal>
-        </div>
-      </section>
+      <SupportIntro />
 
       <section className={styles.methods}>
         <div className={styles.methodsContainer}>
           {supportMethods.map((method, index) => (
-            <ScrollReveal key={index} delay={index * 150}>
-              <div
-                className={`${styles.card} ${styles[method.color]} ${index % 2 !== 0 ? styles.reverse : ''}`}
-              >
-                <div className={styles.cardImageWrapper}>
-                  <Image
-                    src={method.image}
-                    alt={method.imageAlt}
-                    fill
-                    sizes="(max-width: 640px) 100vw, 50vw"
-                    quality={75}
-                    className={styles.cardImage}
-                  />
-                </div>
-                <div className={styles.cardContent}>
-                  <span className={styles.cardNumber}>{method.number}</span>
-                  <h3 className={styles.cardTitle}>{method.title}</h3>
-                  <p className={styles.cardDescription}>{method.description}</p>
-                  <div className={styles.cardCta}>
-                    {method.ctaType === 'single' ? (
-                      <ButtonLink href={`/support/${method.slug}`} variant="outline">
-                        ボランティアに参加する
-                      </ButtonLink>
-                    ) : (
-                      <>
-                        <ButtonLink href={`/support/${method.slug}`} variant="outline">
-                          個人の方はこちら
-                        </ButtonLink>
-                        <ButtonLink href={`/support/${method.slug}`} variant="outline">
-                          法人・団体の方はこちら
-                        </ButtonLink>
-                      </>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </ScrollReveal>
+            <SupportMethodCard key={index} method={method} index={index} />
           ))}
         </div>
       </section>

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -17,7 +17,8 @@ docs/
 │   └── business-plan.md      # 放課後こどもラボ事業計画書
 ├── dev/                      # 開発関連ドキュメント
 │   ├── domain-setup.md       # カスタムドメイン設定ガイド
-│   └── email-setup.md        # メール送信設定ガイド
+│   ├── email-setup.md        # メール送信設定ガイド
+│   └── site-migration.md     # 旧サイト移行ガイド
 └── design/                   # デザイン関連ドキュメント
     ├── design-system.md      # デザインシステム（元の詳細プラン、参考用）
     ├── color-system.md       # カラーシステム詳細
@@ -47,6 +48,12 @@ docs/
   - リダイレクト設定（www → apex、Vercel デフォルト → apex）
   - SSL / HTTPS 設定
   - 設定変更時のチェックリスト
+
+- **[site-migration.md](./dev/site-migration.md)** - 旧サイト（ldl.cocotte.jp）→ 新サイト（pldl.or.jp）移行ガイド
+  - 301リダイレクト設定手順（.htaccess / WordPressプラグイン）
+  - Google Search Console アドレス変更申請
+  - 主要ページのURLマッピング
+  - 移行後の確認・監視チェックリスト
 
 - **[email-setup.md](./dev/email-setup.md)** - お問い合わせフォーム メール送信設定ガイド
   - SMTP環境変数一覧と設定手順
@@ -123,4 +130,4 @@ docs/
 
 ---
 
-最終更新日: 2026-03-22
+最終更新日: 2026-03-24

--- a/docs/dev/site-migration.md
+++ b/docs/dev/site-migration.md
@@ -1,0 +1,133 @@
+# 旧サイト（ldl.cocotte.jp）→ 新サイト（pldl.or.jp）移行ガイド
+
+## 概要
+
+旧サイト `https://ldl.cocotte.jp/`（WordPress）から新サイト `https://pldl.or.jp`（Next.js / Vercel）へのドメイン移行に伴うSEO対応手順をまとめたドキュメント。
+
+### 現状
+
+| 項目 | 旧サイト | 新サイト |
+|------|---------|---------|
+| URL | `https://ldl.cocotte.jp/` | `https://pldl.or.jp` |
+| CMS | WordPress + All in One SEO v4.4.4 | Next.js 16 + microCMS |
+| ホスティング | さくらサーバー（推定） | Vercel |
+| 状態 | **稼働中（リダイレクトなし）** | 公開済み |
+
+### 対応が必要な理由
+
+- 旧サイトと新サイトが同時に稼働しており、Googleが「重複コンテンツ」と判断するリスクがある
+- 旧サイトへの被リンク評価が新サイトに引き継がれていない
+- 旧サイトのcanonicalが自己参照（`ldl.cocotte.jp`）のままで、新サイトへの誘導がゼロ
+
+---
+
+## 移行手順
+
+### Step 1: 旧サイトに301リダイレクトを設定（最重要）
+
+旧サイトのサーバーで、全URLを新サイトに**301（恒久的）リダイレクト**する設定を行う。
+
+#### 方法A: .htaccess による一括リダイレクト（推奨）
+
+旧サイトのドキュメントルートにある `.htaccess` ファイルに以下を追記する。
+既存の WordPress 用 RewriteRule より**上**に配置すること。
+
+```apache
+# === 新サイトへの301リダイレクト（2026年追加） ===
+RewriteEngine On
+RewriteCond %{HTTP_HOST} ^(www\.)?ldl\.cocotte\.jp$ [NC]
+RewriteRule ^(.*)$ https://pldl.or.jp/$1 [R=301,L]
+```
+
+#### 方法B: WordPress プラグインによるリダイレクト
+
+サーバーの `.htaccess` を直接編集できない場合は、WordPress プラグインを使用する。
+
+1. WordPress 管理画面にログイン（`https://ldl.cocotte.jp/wordpress/wp-admin/`）
+2. プラグイン「Redirection」をインストール・有効化
+3. 設定画面で以下を設定:
+   - **ソースURL**: `/(.*)`（正規表現チェック ON）
+   - **ターゲットURL**: `https://pldl.or.jp/$1`
+   - **HTTPステータス**: 301（恒久的リダイレクト）
+
+#### 確認方法
+
+```bash
+# ターミナルで301リダイレクトの確認
+curl -I https://ldl.cocotte.jp/
+# → HTTP/1.1 301 Moved Permanently
+# → Location: https://pldl.or.jp/
+
+curl -I https://ldl.cocotte.jp/blog/some-post/
+# → HTTP/1.1 301 Moved Permanently
+# → Location: https://pldl.or.jp/blog/some-post/
+```
+
+### Step 2: 主要ページのURLマッピング（任意・推奨）
+
+旧サイトと新サイトでURL構造が異なるページがある場合は、個別のリダイレクトルールを追加する。
+
+Step 1 の一括リダイレクトで対応できない場合のみ、以下のように個別ルールを `.htaccess` の一括ルール**より上**に追記する。
+
+```apache
+# 個別ページのリダイレクト（一括ルールより上に配置）
+RewriteRule ^blog/(.*)$ https://pldl.or.jp/activities/$1 [R=301,L]
+RewriteRule ^about/?$ https://pldl.or.jp/about [R=301,L]
+RewriteRule ^contact/?$ https://pldl.or.jp/contact [R=301,L]
+```
+
+### Step 3: Google Search Console でアドレス変更を申請
+
+1. [Google Search Console](https://search.google.com/search-console/) にアクセス
+2. 旧ドメイン `ldl.cocotte.jp` と新ドメイン `pldl.or.jp` の**両方**をプロパティとして登録（未登録の場合）
+   - 「ドメイン」プロパティで登録するのが推奨（DNS TXTレコードで認証）
+3. 旧ドメインのプロパティを選択
+4. 「設定」→「アドレス変更」を選択
+5. 新しいサイトとして `pldl.or.jp` を指定
+6. Googleの検証項目（301リダイレクト確認等）をパスして申請完了
+
+### Step 4: 旧サイトの robots.txt を更新（任意）
+
+301リダイレクトが正常に動作していれば不要だが、念のため旧サイトの `robots.txt` を以下に更新してもよい。
+
+```
+User-agent: *
+Disallow: /
+
+# 新サイトへ移行しました
+# https://pldl.or.jp
+```
+
+---
+
+## 移行後の確認・監視
+
+### 直後の確認（1週間以内）
+
+- [ ] 旧サイトの全ページが301でリダイレクトされることを確認（`curl -I` でテスト）
+- [ ] 新サイトが正常に表示されることを確認
+- [ ] Google Search Console でエラーが発生していないことを確認
+
+### 継続的な監視（1〜3ヶ月）
+
+- [ ] Search Console の「カバレッジ」レポートで、旧URLが「リダイレクト」として処理されていることを確認
+- [ ] `site:ldl.cocotte.jp` でGoogle検索し、インデックスが徐々に減少していることを確認
+- [ ] `site:pldl.or.jp` でGoogle検索し、インデックスが増加していることを確認
+- [ ] 主要キーワードでの検索順位を監視（「放課後こどもラボ」「PLDL」「みどり市 NPO」等）
+
+### 注意事項
+
+- **旧サイトの301リダイレクトは最低1年間は維持すること**。すぐにサーバーを停止するとSEO評価の引き継ぎが不完全になる
+- 旧サイトのWordPressは管理画面にアクセスできる状態を維持しておくことが望ましい（緊急時の対応のため）
+- 被リンクが多い特定ページがある場合は、そのページの個別リダイレクトを優先的に設定する
+
+---
+
+## 参考情報
+
+- [Google公式: サイトの移転](https://developers.google.com/search/docs/crawling-indexing/site-move-with-url-changes)
+- [Google Search Console ヘルプ: アドレス変更ツール](https://support.google.com/webmasters/answer/9370220)
+
+---
+
+最終更新日: 2026-03-24


### PR DESCRIPTION
## Summary
- ParallaxSectionコンポーネントを新規作成（GSAP ScrollTrigger + gsap.matchMediaによるモバイル/reduced-motion制御）
- Vision・Mission・活動レポートセクションにスクロール連動パララックス効果を適用
- `data-parallax-speed` 属性によるセクション固有のカスタム速度オーバーライド機能を追加
- Footer/SNS/構造化データのInstagram URLを公式アカウントURLに修正
- 旧サイト移行ガイド（docs/dev/site-migration.md）を追加

## 変更ファイル
- `app/_components/ParallaxSection/` - 新規コンポーネント（index.tsx + index.module.css）
- `app/_components/VisionSection/` - data-parallax属性追加、padding調整
- `app/_components/MissionSection/` - data-parallax属性追加、padding調整
- `app/page.tsx` - 活動レポートセクションにParallaxSection適用、Instagram URL修正
- `app/_components/Footer/index.tsx` - Instagram URL修正
- `app/layout.tsx` - 構造化データにsameAs追加
- `docs/INDEX.md` / `docs/dev/site-migration.md` - ドキュメント追加・更新

## Test plan
- [ ] デスクトップ（769px以上）でスクロール時にVision/Mission/活動レポートセクションのパララックス効果を確認
- [ ] モバイル（768px以下）でパララックスが無効化されることを確認
- [ ] `prefers-reduced-motion: reduce` でパララックスが無効化されることを確認
- [ ] `pnpm build` でビルドエラーなしを確認（確認済み）
- [ ] Instagram URLが正しいアカウントページに遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)