### PR TITLE
FEAT: 各事業詳細ページを拡充（空間設計・出張WS・こどもラボの3事業）

### DIFF
--- a/app/_components/BusinessIntro/index.module.css
+++ b/app/_components/BusinessIntro/index.module.css
@@ -286,7 +286,7 @@
   display: block;
   width: 100%;
   height: auto;
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 1 / 1;
   object-fit: cover;
   border-radius: var(--border-radius-lg);
   box-shadow: var(--shadow-lg);
@@ -317,7 +317,7 @@
 
 .scopeImageWrap {
   width: 100%;
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 1 / 1;
   overflow: hidden;
 }
 

--- a/app/_components/BusinessIntro/index.module.css
+++ b/app/_components/BusinessIntro/index.module.css
@@ -191,13 +191,21 @@
 
 /* ===== レスポンシブ ===== */
 @media (max-width: 920px) {
+  /* タブレット以下はフローを1列にし、番号順序を一直線で示す（2列折り返しでの分断を回避） */
   .flow {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: 1fr;
   }
 
-  /* 2列時は右端カードの矢印を消す */
-  .flowStep:nth-child(2n)::after {
-    display: none;
+  /* すべてのステップ間を下向き矢印で連結 */
+  .flowStep:not(:last-child)::after {
+    top: auto;
+    bottom: -16px;
+    right: 50%;
+    transform: translateX(50%);
+    border-top: 8px solid var(--color-primary-light);
+    border-bottom: 0;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
   }
 }
 
@@ -219,25 +227,8 @@
     margin-bottom: var(--spacing-8);
   }
 
-  .featureGrid,
-  .flow {
+  .featureGrid {
     grid-template-columns: 1fr;
-  }
-
-  /* 縦積み時はすべてのステップに下向き矢印を復活 */
-  .flowStep:not(:last-child)::after {
-    top: auto;
-    bottom: -16px;
-    right: 50%;
-    transform: translateX(50%);
-    border-top: 8px solid var(--color-primary-light);
-    border-bottom: 0;
-    border-left: 6px solid transparent;
-    border-right: 6px solid transparent;
-  }
-
-  .flowStep:nth-child(2n)::after {
-    display: block;
   }
 }
 

--- a/app/_components/BusinessIntro/index.module.css
+++ b/app/_components/BusinessIntro/index.module.css
@@ -1,0 +1,390 @@
+.intro {
+  padding: var(--spacing-16) var(--spacing-4);
+  background: linear-gradient(
+    180deg,
+    rgba(245, 166, 35, 0.05) 0%,
+    rgba(78, 205, 196, 0.05) 100%
+  );
+}
+
+.container {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+/* ===== ヘッダー（コンセプト・リード文） ===== */
+.header {
+  max-width: 760px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.accent {
+  width: 48px;
+  height: 4px;
+  border-radius: var(--border-radius-full);
+  background: var(--color-primary);
+  margin: 0 auto var(--spacing-4);
+}
+
+.subEn {
+  font-family: var(--font-display);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  letter-spacing: 0.06em;
+  color: var(--color-secondary-dark);
+  margin-bottom: var(--spacing-3);
+}
+
+.tagline {
+  font-family: var(--font-display);
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-5);
+  text-wrap: balance;
+}
+
+.lead {
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
+  color: var(--color-text-primary);
+}
+
+.lead + .lead {
+  margin-top: var(--spacing-4);
+}
+
+/* ===== グループ（特徴カード / フロー） ===== */
+.group {
+  margin-top: var(--spacing-16);
+}
+
+.groupHeading {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  text-align: center;
+  margin-bottom: var(--spacing-10);
+}
+
+.groupHeading::after {
+  content: '';
+  display: block;
+  width: 40px;
+  height: 3px;
+  border-radius: var(--border-radius-full);
+  background: var(--color-tertiary-dark);
+  margin: var(--spacing-3) auto 0;
+}
+
+/* ===== 特徴カード（3つの育み・3本柱） ===== */
+.featureGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-6);
+}
+
+.featureCard {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-main);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--border-radius-lg);
+  padding: var(--spacing-8) var(--spacing-6) var(--spacing-6);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.featureCard:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+}
+
+.featureNumber {
+  font-family: var(--font-display);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-primary);
+  line-height: 1;
+}
+
+.featureTitle {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  color: var(--color-text-primary);
+  margin: var(--spacing-3) 0;
+}
+
+.featureDesc {
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-primary);
+}
+
+/* ===== フロー（実施の流れ） ===== */
+.flow {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--spacing-6);
+}
+
+.flowStep {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  background: var(--color-bg-main);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--border-radius-lg);
+  padding: var(--spacing-8) var(--spacing-4) var(--spacing-6);
+  box-shadow: var(--shadow-sm);
+}
+
+/* ステップ間の矢印（デスクトップ: 右向き） */
+.flowStep:not(:last-child)::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  right: -16px;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 8px solid var(--color-primary-light);
+}
+
+.flowNumber {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: var(--border-radius-full);
+  background: var(--color-primary);
+  color: var(--color-text-unpainted);
+  font-family: var(--font-display);
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-bold);
+  line-height: 1;
+  margin-bottom: var(--spacing-4);
+  box-shadow: var(--shadow-primary-sm);
+}
+
+.flowTitle {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-2);
+}
+
+.flowDesc {
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-primary);
+}
+
+/* ===== レスポンシブ ===== */
+@media (max-width: 920px) {
+  .flow {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  /* 2列時は右端カードの矢印を消す */
+  .flowStep:nth-child(2n)::after {
+    display: none;
+  }
+}
+
+@media (max-width: 768px) {
+  .intro {
+    padding: var(--spacing-12) var(--spacing-4);
+  }
+
+  .tagline {
+    font-size: var(--font-size-2xl);
+  }
+
+  .group {
+    margin-top: var(--spacing-12);
+  }
+
+  .groupHeading {
+    font-size: var(--font-size-lg);
+    margin-bottom: var(--spacing-8);
+  }
+
+  .featureGrid,
+  .flow {
+    grid-template-columns: 1fr;
+  }
+
+  /* 縦積み時はすべてのステップに下向き矢印を復活 */
+  .flowStep:not(:last-child)::after {
+    top: auto;
+    bottom: -16px;
+    right: 50%;
+    transform: translateX(50%);
+    border-top: 8px solid var(--color-primary-light);
+    border-bottom: 0;
+    border-left: 6px solid transparent;
+    border-right: 6px solid transparent;
+  }
+
+  .flowStep:nth-child(2n)::after {
+    display: block;
+  }
+}
+
+/* ===== 画像リード（テキスト + 画像の2カラム） ===== */
+.leadGrid {
+  display: grid;
+  grid-template-columns: 1.05fr 1fr;
+  gap: var(--spacing-12);
+  align-items: center;
+}
+
+.leadText {
+  text-align: left;
+}
+
+/* 中央寄せヘッダー用の .accent は auto マージンだが、リードでは左寄せに */
+.leadText .accent {
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.leadImageWrap {
+  position: relative;
+}
+
+/* 画像背後の装飾パネル（立体感） */
+.leadImageWrap::before {
+  content: '';
+  position: absolute;
+  right: -14px;
+  bottom: -14px;
+  width: 55%;
+  height: 70%;
+  border-radius: var(--border-radius-lg);
+  background: linear-gradient(
+    135deg,
+    rgba(78, 205, 196, 0.35),
+    rgba(255, 230, 109, 0.45)
+  );
+  z-index: 0;
+}
+
+.leadImage {
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: var(--border-radius-lg);
+  box-shadow: var(--shadow-lg);
+}
+
+/* ===== デザイン領域（scope: 画像トップのカード） ===== */
+.scopeGrid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--spacing-6);
+}
+
+.scopeCard {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-bg-main);
+  border: 1px solid var(--color-border-light);
+  border-radius: var(--border-radius-lg);
+  overflow: hidden;
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.scopeCard:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-md);
+}
+
+.scopeImageWrap {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+}
+
+.scopeImage {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.scopeBody {
+  padding: var(--spacing-6);
+}
+
+.scopeTitle {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-bold);
+  line-height: var(--line-height-tight);
+  color: var(--color-text-primary);
+  margin-bottom: var(--spacing-2);
+}
+
+.scopeDesc {
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-primary);
+}
+
+/* ===== CTA ===== */
+.ctaWrap {
+  display: flex;
+  justify-content: center;
+  margin-top: var(--spacing-12);
+}
+
+/* ===== 画像リード・scope のレスポンシブ ===== */
+@media (max-width: 920px) {
+  .leadGrid {
+    gap: var(--spacing-8);
+  }
+}
+
+@media (max-width: 768px) {
+  .leadGrid {
+    grid-template-columns: 1fr;
+  }
+
+  /* モバイルでは画像を先頭に */
+  .leadImageWrap {
+    order: -1;
+  }
+
+  .scopeGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ===== モーション低減 ===== */
+@media (prefers-reduced-motion: reduce) {
+  .featureCard,
+  .scopeCard {
+    transition: none;
+  }
+
+  .featureCard:hover,
+  .scopeCard:hover {
+    transform: none;
+    box-shadow: var(--shadow-sm);
+  }
+}

--- a/app/_components/BusinessIntro/index.tsx
+++ b/app/_components/BusinessIntro/index.tsx
@@ -1,0 +1,129 @@
+import Image from 'next/image';
+import type { BusinessDetail } from '@/app/_constants/businesses';
+import ButtonLink from '@/app/_components/ButtonLink';
+import styles from './index.module.css';
+
+type Props = {
+  business: BusinessDetail;
+};
+
+/**
+ * 事業詳細ページ（/activities?category=<事業>）の先頭に表示する事業紹介セクション。
+ * コンセプト・リード文・特徴カード・デザイン領域・実施フロー・CTA を描画する。
+ * 各ブロックはデータの有無で出し分けるため、事業ごとに情報量が異なってもよい。
+ */
+export default function BusinessIntro({ business }: Props) {
+  const { name, subEn, tagline, lead, image, featureGroups, scope, flow, cta } = business;
+
+  return (
+    <section className={styles.intro} aria-label={`${name}の紹介`}>
+      <div className={styles.container}>
+        {image ? (
+          // 画像リード: テキスト＋画像の2カラム
+          <div className={styles.leadGrid}>
+            <div className={styles.leadText}>
+              <div className={styles.accent} aria-hidden="true" />
+              {subEn && <p className={styles.subEn}>{subEn}</p>}
+              <h2 className={styles.tagline}>{tagline}</h2>
+              {lead.map((paragraph, index) => (
+                <p key={index} className={styles.lead}>
+                  {paragraph}
+                </p>
+              ))}
+            </div>
+            <div className={styles.leadImageWrap}>
+              <Image
+                src={image.src}
+                alt={image.alt}
+                width={image.width}
+                height={image.height}
+                className={styles.leadImage}
+                sizes="(max-width: 768px) calc(100vw - 32px), 460px"
+              />
+            </div>
+          </div>
+        ) : (
+          // 従来の中央寄せヘッダー
+          <header className={styles.header}>
+            <div className={styles.accent} aria-hidden="true" />
+            {subEn && <p className={styles.subEn}>{subEn}</p>}
+            <h2 className={styles.tagline}>{tagline}</h2>
+            {lead.map((paragraph, index) => (
+              <p key={index} className={styles.lead}>
+                {paragraph}
+              </p>
+            ))}
+          </header>
+        )}
+
+        {featureGroups?.map((group) => (
+          <div key={group.heading} className={styles.group}>
+            <h3 className={styles.groupHeading}>{group.heading}</h3>
+            <div className={styles.featureGrid}>
+              {group.items.map((item, index) => (
+                <article key={item.title} className={styles.featureCard}>
+                  <span className={styles.featureNumber} aria-hidden="true">
+                    {String(index + 1).padStart(2, '0')}
+                  </span>
+                  <h4 className={styles.featureTitle}>{item.title}</h4>
+                  <p className={styles.featureDesc}>{item.description}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        ))}
+
+        {scope && (
+          <div className={styles.group}>
+            <h3 className={styles.groupHeading}>{scope.heading}</h3>
+            <div className={styles.scopeGrid}>
+              {scope.items.map((item) => (
+                <article key={item.title} className={styles.scopeCard}>
+                  {item.image && (
+                    <div className={styles.scopeImageWrap}>
+                      <Image
+                        src={item.image.src}
+                        alt={item.image.alt}
+                        width={item.image.width}
+                        height={item.image.height}
+                        className={styles.scopeImage}
+                        sizes="(max-width: 768px) calc(100vw - 32px), 300px"
+                      />
+                    </div>
+                  )}
+                  <div className={styles.scopeBody}>
+                    <h4 className={styles.scopeTitle}>{item.title}</h4>
+                    <p className={styles.scopeDesc}>{item.description}</p>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {flow && (
+          <div className={styles.group}>
+            <h3 className={styles.groupHeading}>{flow.heading}</h3>
+            <ol className={styles.flow}>
+              {flow.steps.map((step, index) => (
+                <li key={step.title} className={styles.flowStep}>
+                  <span className={styles.flowNumber} aria-hidden="true">
+                    {index + 1}
+                  </span>
+                  <h4 className={styles.flowTitle}>{step.title}</h4>
+                  <p className={styles.flowDesc}>{step.description}</p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        )}
+
+        {cta && (
+          <div className={styles.ctaWrap}>
+            <ButtonLink href={cta.href}>{cta.label}</ButtonLink>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/_components/BusinessIntro/index.tsx
+++ b/app/_components/BusinessIntro/index.tsx
@@ -61,13 +61,13 @@ export default function BusinessIntro({ business }: Props) {
             <h3 className={styles.groupHeading}>{group.heading}</h3>
             <div className={styles.featureGrid}>
               {group.items.map((item, index) => (
-                <article key={item.title} className={styles.featureCard}>
+                <div key={item.title} className={styles.featureCard}>
                   <span className={styles.featureNumber} aria-hidden="true">
                     {String(index + 1).padStart(2, '0')}
                   </span>
                   <h4 className={styles.featureTitle}>{item.title}</h4>
                   <p className={styles.featureDesc}>{item.description}</p>
-                </article>
+                </div>
               ))}
             </div>
           </div>
@@ -78,7 +78,7 @@ export default function BusinessIntro({ business }: Props) {
             <h3 className={styles.groupHeading}>{scope.heading}</h3>
             <div className={styles.scopeGrid}>
               {scope.items.map((item) => (
-                <article key={item.title} className={styles.scopeCard}>
+                <div key={item.title} className={styles.scopeCard}>
                   {item.image && (
                     <div className={styles.scopeImageWrap}>
                       <Image
@@ -95,7 +95,7 @@ export default function BusinessIntro({ business }: Props) {
                     <h4 className={styles.scopeTitle}>{item.title}</h4>
                     <p className={styles.scopeDesc}>{item.description}</p>
                   </div>
-                </article>
+                </div>
               ))}
             </div>
           </div>

--- a/app/_constants/businesses.ts
+++ b/app/_constants/businesses.ts
@@ -1,0 +1,240 @@
+// 各事業の詳細ページ（/activities?category=<事業カテゴリ>）で表示する紹介コンテンツ。
+// 出典: PLDL 提供の会社紹介資料（HP.pptx）。microCMS のカテゴリ名をキーに保持する。
+
+/** 特徴カード1件 */
+export type BusinessFeature = {
+  title: string;
+  description: string;
+};
+
+/** 特徴カードのグループ（例: 「3つの育み」「3本柱」） */
+export type BusinessFeatureGroup = {
+  heading: string;
+  items: BusinessFeature[];
+};
+
+/** 実施フローの1ステップ */
+export type BusinessFlowStep = {
+  title: string;
+  description: string;
+};
+
+/** 実施フロー全体 */
+export type BusinessFlow = {
+  heading: string;
+  steps: BusinessFlowStep[];
+};
+
+/** 画像（next/image 用に寸法を明示し CLS を防ぐ） */
+export type BusinessImage = {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+};
+
+/** 「デザインする学びの場」など、事業が手がける領域の1件（任意で画像付き） */
+export type BusinessScopeItem = {
+  title: string;
+  description: string;
+  image?: BusinessImage;
+};
+
+/** 事業が手がける領域のグループ */
+export type BusinessScope = {
+  heading: string;
+  items: BusinessScopeItem[];
+};
+
+/** セクション末尾の行動喚起（CTA） */
+export type BusinessCta = {
+  label: string;
+  href: string;
+};
+
+/** 事業詳細コンテンツ */
+export type BusinessDetail = {
+  /** microCMS カテゴリ名（表示条件のキーと一致させる） */
+  name: string;
+  /** 英語サブコピー（任意） */
+  subEn?: string;
+  /** キャッチコピー（見出し） */
+  tagline: string;
+  /** リード文（段落単位で配列に格納） */
+  lead: string[];
+  /** リード画像（あれば画像＋テキストの2カラムでヘッダーを描画） */
+  image?: BusinessImage;
+  /** 特徴カードグループ（任意） */
+  featureGroups?: BusinessFeatureGroup[];
+  /** 事業が手がける領域（任意。画像付きカードで描画） */
+  scope?: BusinessScope;
+  /** 実施フロー（任意） */
+  flow?: BusinessFlow;
+  /** セクション末尾の CTA（任意） */
+  cta?: BusinessCta;
+};
+
+// カテゴリ名 → 事業詳細コンテンツ
+export const BUSINESS_DETAILS: Record<string, BusinessDetail> = {
+  放課後こどもラボ事業: {
+    name: '放課後こどもラボ事業',
+    subEn: 'Creative Learning ↔ Playful Learning',
+    tagline: '創造的な学びから、ワクワクする学びへ',
+    lead: [
+      '放課後こどもラボの活動は「創造的な学び」を軸に設計されています。プロジェクト活動や制作などの創造的な学びを通じて、学ぶことに夢中になったり、好奇心が生まれたり、ワクワクする学びへとつなげていきます。',
+    ],
+    featureGroups: [
+      {
+        heading: 'こどもたちの生きる力を育む活動',
+        items: [
+          {
+            title: '自分で考える',
+            description:
+              'ささいなことでも自分で考えて行動する・答えを出せるように、こどもたちにはたらきかけます。',
+          },
+          {
+            title: '色々な子・大人と関わる／リーダーになる',
+            description:
+              'すべての活動にリーダーの役割があります。役割・責任がこどもの成長を育み、異年齢で遊ぶ・活動する文化を醸成。様々な大人との関わりをつくります。',
+          },
+          {
+            title: '得意を頑張る／興味を伸ばす',
+            description:
+              'ひとつのプロジェクトの中で、自分のできることでチームに貢献してもらいます。こどもたちの興味を伸ばす手助けをします。',
+          },
+        ],
+      },
+      {
+        heading: '放課後こどもラボの3本柱',
+        items: [
+          {
+            title: '自分で考える平日の遊び',
+            description:
+              '平日は宿題が終われば自由時間。「今日何して遊ぶ？」という言葉が飛び交い、遊びが生まれます。こどもたちが自分で考え、主体的に遊ぶ平日です。',
+          },
+          {
+            title: 'みんなでやり抜くプロジェクト活動',
+            description:
+              '長期休みは個人・グループでプロジェクト活動。アニメ・劇・映画制作などは学年を縦断したチームでやり抜きます。キャンプやイベントも、こどもたちが主体で実行します。',
+          },
+          {
+            title: '責任と自信を育むリーダー制',
+            description:
+              'すべてのイベント・プロジェクト活動にはリーダーがいます。リーダーを中心に制作や準備が進み、リーダー経験を通じて責任感が生まれ、やり遂げた時には自信がつきます。',
+          },
+        ],
+      },
+    ],
+  },
+
+  出張ワークショップ事業: {
+    name: '出張ワークショップ事業',
+    subEn: 'Original Workshop',
+    tagline: '好奇心と創造力を育む、オリジナルワークショップ',
+    lead: [
+      'PLDLでは、ご要望に合わせてオリジナルのワークショップを企画します。「ワクワクすること・創造的なこと」を大切に、夢中になれるワークショップをみなさんにお届けします。',
+    ],
+    flow: {
+      heading: 'ワークショップ 計画・実施の流れ',
+      steps: [
+        {
+          title: 'ヒアリング',
+          description: 'テーマ・対象者など、基本情報をヒアリングします。',
+        },
+        {
+          title: '企画',
+          description: 'ヒアリング内容に合わせて、ワークショップを企画します。',
+        },
+        {
+          title: '実施準備',
+          description: '企画に合わせて、タイムスケジュールや道具を準備します。',
+        },
+        {
+          title: '実施',
+          description: 'ワークショップを実施。進行のすべてを行います。',
+        },
+      ],
+    },
+  },
+
+  空間設計事業: {
+    name: '空間設計事業',
+    subEn: 'Learning Environment Design',
+    tagline: '学びをたすける、学習環境デザイン',
+    lead: [
+      'PLDLでは、小学校から大学までの教育機関から、図書館・地域の拠点などの公共施設まで、様々な学習環境をデザインします。',
+      'またこどもたちと場をつくる、こども主体の空間ワークショップも実施しています。',
+    ],
+    image: {
+      src: '/photos/kids-floor-plan-design.webp',
+      alt: 'こどもたちが学習環境の平面図をデザインする様子',
+      width: 560,
+      height: 420,
+    },
+    scope: {
+      heading: 'デザインする学びの場',
+      items: [
+        {
+          title: '教育機関の学習環境',
+          description:
+            '小学校から大学まで、こどもたちの学びを促す空間をデザインします。',
+          image: {
+            src: '/photos/children-desk-writing-group.webp',
+            alt: '教室で机に向かい学ぶこどもたち',
+            width: 400,
+            height: 300,
+          },
+        },
+        {
+          title: '公共施設・地域の拠点',
+          description:
+            '図書館や地域の拠点など、人が集い学ぶ場をデザインします。',
+          image: {
+            src: '/photos/kids-reading-together.webp',
+            alt: '本を読み合うこどもたち',
+            width: 400,
+            height: 300,
+          },
+        },
+        {
+          title: 'こども主体の空間ワークショップ',
+          description:
+            'こどもたちと場をつくる、参加型の空間づくりを実施します。',
+          image: {
+            src: '/photos/kids-illustrated-cards-floor.webp',
+            alt: '床にカードを並べて場をつくるこどもたち',
+            width: 400,
+            height: 300,
+          },
+        },
+      ],
+    },
+    flow: {
+      heading: '学習環境デザイン 企画・設計の流れ',
+      steps: [
+        {
+          title: 'ヒアリング',
+          description: '対象となる空間に関するヒアリングを実施します。',
+        },
+        {
+          title: '企画・基本設計',
+          description:
+            'ヒアリング内容を元に、空間の企画・ゾーニング・レイアウトなどの基本設計を行います。',
+        },
+        {
+          title: '各種デザイン',
+          description:
+            'インテリアや家具デザインなど、実施設計に向けてのデザインをします。',
+        },
+        {
+          title: '実施設計',
+          description: '設計事務所と共同で、実施設計を行います。',
+        },
+      ],
+    },
+    cta: {
+      label: '学習環境デザインのご相談',
+      href: '/contact',
+    },
+  },
+};

--- a/app/_constants/businesses.ts
+++ b/app/_constants/businesses.ts
@@ -83,6 +83,12 @@ export const BUSINESS_DETAILS: Record<string, BusinessDetail> = {
     lead: [
       '放課後こどもラボの活動は「創造的な学び」を軸に設計されています。プロジェクト活動や制作などの創造的な学びを通じて、学ぶことに夢中になったり、好奇心が生まれたり、ワクワクする学びへとつなげていきます。',
     ],
+    image: {
+      src: '/photos/kids-collage-craft-room.webp',
+      alt: '室内でコラージュ制作に取り組むこどもたち',
+      width: 1920,
+      height: 1440,
+    },
     featureGroups: [
       {
         heading: 'こどもたちの生きる力を育む活動',
@@ -125,6 +131,10 @@ export const BUSINESS_DETAILS: Record<string, BusinessDetail> = {
         ],
       },
     ],
+    cta: {
+      label: '放課後こどもラボへのお問い合わせ',
+      href: '/contact',
+    },
   },
 
   出張ワークショップ事業: {
@@ -134,6 +144,12 @@ export const BUSINESS_DETAILS: Record<string, BusinessDetail> = {
     lead: [
       'PLDLでは、ご要望に合わせてオリジナルのワークショップを企画します。「ワクワクすること・創造的なこと」を大切に、夢中になれるワークショップをみなさんにお届けします。',
     ],
+    image: {
+      src: '/photos/child-presenting-paper-group.webp',
+      alt: '作品を仲間の前で発表するこども',
+      width: 1920,
+      height: 1440,
+    },
     flow: {
       heading: 'ワークショップ 計画・実施の流れ',
       steps: [
@@ -154,6 +170,10 @@ export const BUSINESS_DETAILS: Record<string, BusinessDetail> = {
           description: 'ワークショップを実施。進行のすべてを行います。',
         },
       ],
+    },
+    cta: {
+      label: '出張ワークショップのご相談',
+      href: '/contact',
     },
   },
 

--- a/app/_constants/businesses.ts
+++ b/app/_constants/businesses.ts
@@ -168,8 +168,8 @@ export const BUSINESS_DETAILS: Record<string, BusinessDetail> = {
     image: {
       src: '/photos/kids-floor-plan-design.webp',
       alt: 'こどもたちが学習環境の平面図をデザインする様子',
-      width: 560,
-      height: 420,
+      width: 1440,
+      height: 1920,
     },
     scope: {
       heading: 'デザインする学びの場',
@@ -181,8 +181,8 @@ export const BUSINESS_DETAILS: Record<string, BusinessDetail> = {
           image: {
             src: '/photos/children-desk-writing-group.webp',
             alt: '教室で机に向かい学ぶこどもたち',
-            width: 400,
-            height: 300,
+            width: 1920,
+            height: 1440,
           },
         },
         {
@@ -192,8 +192,8 @@ export const BUSINESS_DETAILS: Record<string, BusinessDetail> = {
           image: {
             src: '/photos/kids-reading-together.webp',
             alt: '本を読み合うこどもたち',
-            width: 400,
-            height: 300,
+            width: 1440,
+            height: 1920,
           },
         },
         {
@@ -203,8 +203,8 @@ export const BUSINESS_DETAILS: Record<string, BusinessDetail> = {
           image: {
             src: '/photos/kids-illustrated-cards-floor.webp',
             alt: '床にカードを並べて場をつくるこどもたち',
-            width: 400,
-            height: 300,
+            width: 1440,
+            height: 1920,
           },
         },
       ],

--- a/app/activities/page.tsx
+++ b/app/activities/page.tsx
@@ -7,8 +7,11 @@ import Sheet from '@/app/_components/Sheet';
 import ReportsList from '@/app/_components/ReportsList';
 import Pagination from '@/app/_components/Pagination';
 import BusinessCard from '@/app/_components/BusinessCard';
+import BusinessIntro from '@/app/_components/BusinessIntro';
 import CategoryFilter from '@/app/_components/CategoryFilter';
 import ReportsReveal from '@/app/_components/ReportsReveal';
+import ScrollReveal from '@/app/_components/ScrollReveal';
+import { BUSINESS_DETAILS } from '@/app/_constants/businesses';
 import styles from './page.module.css';
 
 type Props = {
@@ -25,6 +28,23 @@ export async function generateMetadata({ searchParams }: Props): Promise<Metadat
       const activeNames = categoriesData.contents
         .filter((cat) => selectedIds.includes(cat.id))
         .map((cat) => cat.name);
+
+      // 単一事業カテゴリ選択時は、事業紹介向けのメタデータを出力
+      if (activeNames.length === 1) {
+        const detail = BUSINESS_DETAILS[activeNames[0]];
+        if (detail) {
+          const bizTitle = `${detail.name}｜${detail.tagline}`;
+          return {
+            title: bizTitle,
+            description: detail.lead[0],
+            openGraph: {
+              title: bizTitle,
+              description: detail.lead[0],
+            },
+            alternates: { canonical: '/activities' },
+          };
+        }
+      }
 
       if (activeNames.length > 0) {
         const joined = activeNames.join('・');
@@ -85,9 +105,21 @@ export default async function Page({ searchParams }: Props) {
       ? `「${activeCategories.map((c) => c.name).join('・')}」の活動レポート`
       : '活動レポート';
 
+  // 単一事業カテゴリ選択時のみ、その事業の紹介セクションを表示する
+  const singleBusiness =
+    activeCategories.length === 1
+      ? (BUSINESS_DETAILS[activeCategories[0].name] ?? null)
+      : null;
+
   return (
     <>
       <Hero title="活動内容" sub="Activities" imageSrc="/photos/kids-craft-activity-table.webp" />
+
+      {singleBusiness && (
+        <ScrollReveal>
+          <BusinessIntro business={singleBusiness} />
+        </ScrollReveal>
+      )}
 
       <Sheet id="reports">
         <ReportsReveal>


### PR DESCRIPTION
## 概要

Epic #24: 各事業の詳細ページ（＝ `/activities?category=<事業>` の活動一覧フィルタ画面）に事業紹介セクションを追加し、**3事業すべてを拡充**する。

- 共通基盤: 汎用コンポーネント `BusinessIntro`（任意フィールド `image` / `featureGroups` / `scope` / `flow` / `cta` を出し分け描画）＋ 事業データ定数 `businesses.ts`
- 3事業を同一の作法で拡充（画像リード＋各中間コンテンツ＋CTA）
- コンテンツ出典: PLDL 会社紹介資料（`HP.pptx`）。ソース内定数で管理し、microCMS スキーマは不変

関連: **Closes #25 / #26 / #27**（Epic #24 は本PRマージ後にクローズ）

## 各事業の詳細ページ構成

| 事業 | 構成 |
|---|---|
| 空間設計事業（#27） | 画像リード → デザイン領域3カード（画像付き） → 4ステップ設計フロー → CTA |
| 出張ワークショップ事業（#25） | 画像リード → 4ステップ実施フロー → CTA |
| 放課後こどもラボ事業（#26） | 画像リード → 「3つの育み」「3本柱」カード → CTA |

## 変更ファイル

- `app/_constants/businesses.ts`（新規）— 事業データ＋型（`BusinessDetail` ほか）
- `app/_components/BusinessIntro/`（新規, tsx＋css）— 画像リード / 特徴カード / scope / フロー / CTA を任意描画するサーバーコンポーネント（CSS変数準拠・レスポンシブ・`prefers-reduced-motion` 対応）
- `app/activities/page.tsx`（修正）— 単一事業カテゴリ選択時に `BusinessIntro` を描画＋事業向けメタデータ（title / description）出力

## 実装方針

- 新規ルートを作らず既存 `/activities?category=X` を拡張
- microCMS スキーマは変更せず、内容はソース内定数で保持
- 画像は `next/image`（`sizes` / `width`/`height` 明示で CLS 防止、正方形 `aspect-ratio:1/1` 表示、ファーストビュー外のため `priority` なし。宣言寸法は実ファイルの実寸に一致）
- リビールは既存 `ScrollReveal`（IntersectionObserver・reduced-motion対応）に委譲し、GSAP / FOUC 登録は不要
- 資料上の「空間デザイン事業」は既存コード / microCMS の「空間設計事業」に統一

## コミット構成（4件）

1. `f16fca1` FEAT: 共通基盤（`BusinessIntro` / `businesses.ts`）＋空間設計事業の拡充
2. `10ec137` FIX: レビュー対応(Low) 画像宣言寸法を実寸に是正＋正方形表示でクロップ緩和
3. `9c0406e` REFACTOR: レビュー対応(Nit×2) カード `<article>`→`<div>` / タブレット幅フローの連結改善
4. `3fc5a28` FEAT: 横展開 出張ワークショップ・放課後こどもラボに画像リード＋CTA追加

## 検証

- `pnpm typecheck` / `pnpm lint` / `pnpm build` — すべて緑（全18ページ生成）
- 実機（Claude in Chrome / サーバーHTML）— 3事業すべてで画像リード・中間コンテンツ・CTA・メタデータの描画を確認。相互の回帰なし
- セルフレビュー（多観点並列探索＋反証検証）実施済み。High/Middle なし。指摘（Low×1 / Nit×2）は本PR内のコミットで対応済み
- 補足: `next/font/google` の gstatic 取得は一過性で失敗しうるが、フォント設定は不変・再ビルドで緑（環境要因）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
