### PR TITLE
CHORE: 開発時UIアノテーションツール Agentation を導入

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/app/_constants';
 import Footer from '@/app/_components/Footer';
 import Header from '@/app/_components/Header';
+import { Agentation } from 'agentation';
 import './globals.css';
 import styles from './layout.module.css';
 
@@ -143,6 +144,8 @@ export default async function RootLayout({ children }: Props) {
         <Header />
         <main className={styles.main}>{children}</main>
         <Footer />
+        {/* 開発時のみ: Agentation ツールバー（本番ビルドからは NODE_ENV ガードで自動除外） */}
+        {process.env.NODE_ENV === 'development' && <Agentation />}
       </body>
     </html>
   );

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@types/nodemailer": "^7.0.11",
+    "agentation": "^3.0.2",
     "eslint": "^9.25.0",
     "eslint-config-next": "^16.1.7",
     "eslint-config-prettier": "^10.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@types/nodemailer':
         specifier: ^7.0.11
         version: 7.0.11
+      agentation:
+        specifier: ^3.0.2
+        version: 3.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       eslint:
         specifier: ^9.25.0
         version: 9.39.4
@@ -651,6 +654,17 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  agentation@3.0.2:
+    resolution: {integrity: sha512-iGzBxFVTuZEIKzLY6AExSLAQH6i6SwxV4pAu7v7m3X6bInZ7qlZXAwrEqyc4+EfP4gM7z2RXBF6SF4DeH0f2lA==}
+    peerDependencies:
+      react: '>=18.0.0'
+      react-dom: '>=18.0.0'
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
@@ -2447,6 +2461,11 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  agentation@3.0.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    optionalDependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   ajv@6.14.0:
     dependencies:


### PR DESCRIPTION
## 概要

開発時のUIフィードバックを構造化コンテキスト化してAIコーディングエージェント（Claude Code 等）に渡すツール **Agentation** を導入する。

- UI要素をクリック→注釈→CSSセレクタ・ファイルパス・コンポーネント階層・算出スタイルを含む出力を生成
- **開発時専用**（`NODE_ENV === 'development'` ガードで本番ビルドからは自動除外）
- 追加ランタイム依存ゼロ（React18+ のみ）

## 変更内容
- `agentation@3.0.2` を devDependency に追加（`package.json` / `pnpm-lock.yaml`）
- `app/layout.tsx` の `<body>` 末尾に `{process.env.NODE_ENV === 'development' && <Agentation />}` を結線

## 検証
- `pnpm typecheck` / `pnpm lint` — 緑
- dev サーバー（`localhost:3001`）が HTTP 200＋HTML に agentation を注入し、ツールバー読み込みを確認
- 本番ビルドは `NODE_ENV` ガードで除外（バンドル影響なし）

## 補足
- MCP連携（リアルタイム同期）は未設定。必要時に `npx agentation-mcp init` で追加可能
- 事業詳細ページの PR #28 とは独立した開発ツール導入

🤖 Generated with [Claude Code](https://claude.com/claude-code)
